### PR TITLE
Fix/heroku deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: yarn db:migrations --env=production
+release: npm run db:migrate --env=production
 web: yarn start -p $PORT

--- a/README.md
+++ b/README.md
@@ -19,13 +19,20 @@ Pizzly is made available as an open-source project by [Bearer.sh](https://bearer
 
 ## Summary
 
-- [Why Pizzly?](#why-pizzly)
-- [How it works](#how-it-works)
-- [Key Features](#key-features)
-- [Installation](#installation)
-- [Getting Started](#getting-started)
-- [Supported APIs](#supported-apis)
-- [License](#license)
+- [Pizzly 🐻 - The OAuth Integration Proxy](#pizzly----the-oauth-integration-proxy)
+  - [Summary](#summary)
+  - [Why Pizzly?](#why-pizzly)
+  - [How it works?](#how-it-works)
+    - [Understanding the **AuthId** concept](#understanding-the-authid-concept)
+  - [Key Features](#key-features)
+  - [Installation](#installation)
+    - [Manual Install](#manual-install)
+    - [Heroku Install](#heroku-install)
+  - [Getting Started](#getting-started)
+    - [Using Pizzly as a complete API proxy](#using-pizzly-as-a-complete-api-proxy)
+    - [Using Pizzly as an OAuth manager](#using-pizzly-as-an-oauth-manager)
+  - [Supported APIs](#supported-apis)
+  - [License](#license)
 
 ## Why Pizzly?
 
@@ -70,6 +77,7 @@ To run Pizzly on your machine, follow these steps (or [follow our step-by-step g
 git clone https://github.com/Bearer/Pizzly
 cd pizzly
 yarn install
+yarn db:setup
 yarn start
 ```
 

--- a/app.json
+++ b/app.json
@@ -5,6 +5,10 @@
   "repository": "https://github.com/Bearer/Pizzly",
   "keywords": ["OAuth", "node"],
   "addons": ["heroku-postgresql:hobby-dev"],
+  "scripts": {
+    "postdeploy": "npm run db:create --env=production && npm run db:migrate --env=production"
+  },
+  "success_url": "/",
   "env": {
     "DASHBOARD_USER": {
       "description": "The username to protect access to your Pizzly's dashboard.",
@@ -18,17 +22,19 @@
     },
     "SECRET_KEY": {
       "description": "An unguessable string used to authenticate server-to-server requests.",
-      "default": "",
+      "generator": "secret",
       "required": false
     },
     "PUBLISHABLE_KEY": {
       "description": "An unguessable string used to authenticate frontend-to-server requests.",
       "default": "",
+      "generator": "secret",
       "required": false
     },
     "COOKIE_SECRET": {
       "description": "An unguessable string to sign and verify cookie session.",
       "default": "cookie_secret",
+      "generator": "secret",
       "required": false
     },
     "PROXY_USES_SECRET_KEY_ONLY": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "main": "dist/src/index.js",
   "types": "src/types.d.ts",
   "scripts": {
-    "prepare": "npm run build && npm run db:create && npm run db:migrate",
+    "prepare": "npm run build",
     "build": "rimraf dist/ && tsc -p tsconfig.json",
     "start": "node dist/src",
+    "db:setup": "npm run db:create && npm run db:migrate",
     "db:create": "node dist/config/createDatabase",
     "db:migrate": "knex --cwd dist/config migrate:latest",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "main": "dist/src/index.js",
   "types": "src/types.d.ts",
   "scripts": {
-    "prepare": "npm run build && npm run db:creation && npm run db:migrations",
+    "prepare": "npm run build && npm run db:create && npm run db:migrate",
     "build": "rimraf dist/ && tsc -p tsconfig.json",
     "start": "node dist/src",
-    "db:creation": "node dist/config/createDatabase",
-    "db:migrations": "knex --cwd dist/config migrate:latest",
+    "db:create": "node dist/config/createDatabase",
+    "db:migrate": "knex --cwd dist/config migrate:latest",
     "test": "jest"
   },
   "engines": {


### PR DESCRIPTION
# What

- update app.json to run `db:setup`
- add a secret generator (so that people don't need to generate them)
- rename some DB commands to match the rails way

# Why

- deploy to Heroku button was not working out of the box

# After merging

- wiki needs to be updated to ask people to run `yarn db:setup`  

# Testing 

use this link to deploy to heroku with the current branch 

[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https%3A%2F%2Fgithub.com%2FBearer%2FPizzly/tree/fix/heroku-deploy)

# links

- https://devcenter.heroku.com/articles/app-json-schema
