### PR TITLE
fix: support multiple scopes (one per line)

### DIFF
--- a/src/lib/database/integrations.ts
+++ b/src/lib/database/integrations.ts
@@ -84,7 +84,7 @@ const formatIntegration = (fileName: string, fileContent: any) => {
 export const validateConfigurationScopes = (scopesAsString: string): string[] | null => {
   const scopes: string = ((String(scopesAsString) as string) || '').trim()
 
-  return (scopes && scopes.split('\n')) || null
+  return (scopes && scopes.split(/\r?\n/)) || null
 }
 
 export const validateConfigurationCredentials = (

--- a/views/assets/css/dashboard.css
+++ b/views/assets/css/dashboard.css
@@ -252,6 +252,7 @@ form fieldset label,
 form fieldset .form-input {
   display: inline-block;
   vertical-align: top;
+  font-family: inherit;
 }
 
 form fieldset label {

--- a/views/dashboard/api-configurations-edit.ejs
+++ b/views/dashboard/api-configurations-edit.ejs
@@ -40,7 +40,7 @@
 
           <fieldset>
             <label for="scopes">Scopes</label>
-            <textarea id="scopes" class="form-input" rows="8" name="scopes">
+            <textarea id="scopes" class="form-input" rows="8" name="scopes" placeholder="Add one scope per line.">
 <%= req.data.configuration.scopes.join('\n') %></textarea
             >
           </fieldset>

--- a/views/dashboard/api-configurations-new.ejs
+++ b/views/dashboard/api-configurations-new.ejs
@@ -26,7 +26,13 @@
 
           <fieldset>
             <label for="scopes">Scopes</label>
-            <textarea id="scopes" class="form-input" rows="8" name="scopes"></textarea>
+            <textarea
+              id="scopes"
+              class="form-input"
+              rows="8"
+              name="scopes"
+              placeholder="Add one scope per line."
+            ></textarea>
           </fieldset>
 
           <div class="form-actions">


### PR DESCRIPTION
# Description

Fix an issue with adding new scopes on an API configuration.

![Screenshot 2020-06-01 at 10 53 36](https://user-images.githubusercontent.com/3255133/83392977-4e599f00-a3f6-11ea-8126-c677d383c6e2.png)

The scopes are saved in database using an array, where each item is a scope. The issue was that the scopes wered saved using this format:

```js
[
 "https://www.googleapis.com/auth/spreadsheets\r",
 "https://www.googleapis.com/auth/spreadsheets.readonly"
]
```

Notice the extra `\r`. Updating the `validateConfigurationScopes` fixed the issue.