### PR TITLE
Feat/postman like

### DIFF
--- a/src/clients/javascript/package.json
+++ b/src/clients/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pizzly-js",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A JavaScript library that enables Pizzly on your website",
   "main": "dist/index.js",
   "module": "dist/index.min.mjs",
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "jest",
     "clean": "rimraf dist/",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "build": "npm run clean && tsc --project tsconfig.json && npm run bundle:esm && npm run bundle:esm:min && npm run bundle:umd && npm run bundle:umd:min && npm run build:stats",
     "build:stats": "(echo '\\033[35;3m' ; cd dist && ls -lh index*js index*gz | tail -n +2 | awk '{print $5,$9}')",
     "bundle:esm": "rollup dist/index.js --file dist/index.mjs --format esm",

--- a/src/clients/javascript/src/integration.ts
+++ b/src/clients/javascript/src/integration.ts
@@ -84,7 +84,7 @@ export default class PizzlyIntegration {
    * (using axios behind the scene)
    */
 
-  private request = (method: Types.RequestMethod, endpoint: string, parameters: Types.RequestParameters = {}) => {
+  public request = (method: Types.RequestMethod, endpoint: string, parameters: Types.RequestParameters = {}) => {
     if (parameters && typeof parameters !== 'object') {
       throw new Error(
         'Unable to trigger API request. Request parameters should be an object in the form "{ headers: { "Foo": "bar" }, body: "My body" }'

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -295,6 +295,14 @@ dashboard.get('/:integration/authentications/:authId', async (req, res) => {
 })
 
 /**
+ * Integration > Request
+ */
+
+dashboard.get('/:integration/request', (req, res) => {
+  res.render('dashboard/api-request', { req })
+})
+
+/**
  * Integration > Monitoring
  */
 

--- a/views/assets/css/dashboard.css
+++ b/views/assets/css/dashboard.css
@@ -262,7 +262,7 @@ form fieldset label {
 }
 
 form fieldset .form-input,
-form fieldset .form-json {
+.form-json {
   width: 100%;
   padding: 0.5rem;
   box-sizing: border-box;
@@ -271,7 +271,7 @@ form fieldset .form-json {
   background: #fff;
 }
 
-form fieldset .form-json .json-formatter-string {
+.form-json .json-formatter-string {
   white-space: pre-wrap;
 }
 
@@ -306,8 +306,21 @@ form fieldset .form-hint pre {
 }
 
 /**
- * Content > Pagination
- */
+* Content > API Request
+*/
+
+#proxy-response {
+  height: 1rem;
+  padding: 0.5rem 0;
+}
+
+#proxy-response-body {
+  min-height: 25vh;
+}
+
+/**
+* Content > Pagination
+*/
 
 .pagination {
   margin: 1rem;
@@ -401,7 +414,7 @@ form fieldset .form-hint pre {
   padding: 0.5rem 1rem;
   font-weight: 500;
   background: #e7e7e9;
-  border-radius: 0.5rem;
+  border-radius: 0.25rem;
   border: 1px solid transparent;
   font-size: 0.95rem;
   cursor: pointer;

--- a/views/assets/css/hero.css
+++ b/views/assets/css/hero.css
@@ -66,7 +66,7 @@ nav ul li label {
   padding: 0.5rem 1rem;
   font-weight: 500;
   background: #e7e7e9;
-  border-radius: 0.5rem;
+  border-radius: 0.25rem;
   border: 1px solid transparent;
   font-size: 0.95rem;
   cursor: pointer;

--- a/views/dashboard/api-request.ejs
+++ b/views/dashboard/api-request.ejs
@@ -1,0 +1,104 @@
+<% const base = `/dashboard/${req.params.api}`; %>
+
+<!DOCTYPE html>
+<html>
+  <%- include('layout-head', { title: `Request - ${req.data.api.name} API`}) %>
+
+  <body>
+    <!-- Header -->
+    <%- include('layout-header-api') -%>
+
+    <main class="container">
+      <section>
+        <h2>Request</h2>
+        <form>
+          <fieldset>
+            <label>Method</label>
+            <select id="proxy-method" class="form-input">
+              <option>GET</option>
+              <option>POST</option>
+              <option>PUT</option>
+              <option>DELETE</option>
+            </select>
+          </fieldset>
+
+          <fieldset>
+            <label>Base URL</label>
+            <input value="<%= req.data.api.request.baseURL %>" disabled="disabled" class="form-input" />
+            <p class="form-hint">The base URL has been inferred from the API configuration file.</p>
+          </fieldset>
+
+          <fieldset>
+            <label>Endpoint</label>
+            <input id="proxy-endpoint" placeholder="The API endpoint to request (e.g. /test)" class="form-input" />
+          </fieldset>
+
+          <fieldset>
+            <label>Auth ID</label>
+            <input id="proxy-authid" placeholder="Provide an authId to authenticate the request" class="form-input" />
+          </fieldset>
+
+          <div class="form-actions">
+            <button class="button button-primary" type="submit">Send</button>
+          </div>
+        </form>
+      </section>
+      <section>
+        <h2 style="margin-bottom: 0.5rem;">Response</h2>
+        <div id="proxy-response"></div>
+        <div id="proxy-response-body" class="form-json"></div>
+      </section>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/pizzly-js@latest/dist/index.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/json-formatter-js@2.3.4/dist/json-formatter.umd.min.js"></script>
+    <script>
+      document.forms[0].addEventListener('submit', e => {
+        e.preventDefault()
+
+        const pizzly = new Pizzly('<%= process.env.PUBLISHABLE_KEY %>')
+        const integration = pizzly.integration('<%= req.params.integration %>')
+
+        const method = document.getElementById('proxy-method').value
+        const endpoint = document.getElementById('proxy-endpoint').value
+        const authId = document.getElementById('proxy-authid').value
+
+        const responseHeader = document.getElementById('proxy-response')
+        const responseBody = document.getElementById('proxy-response-body')
+        const responseStart = Date.now()
+
+        responseHeader.innerHTML = 'Loading...'
+        responseBody.innerHTML = ''
+
+        integration
+          .auth(authId)
+          .request(method, endpoint)
+          .then(async response => {
+            // Display response header
+            responseHeader.innerHTML = [
+              `Status: <strong>${response.status} ${response.statusText}</strong>`,
+              `Time: <strong>${Date.now() - responseStart}ms</strong>`
+            ].join(' - ')
+
+            // Handle response body
+            const body = await response.text()
+
+            try {
+              const json = JSON.parse(body)
+              const formatter = new JSONFormatter(json, 'Infinity')
+              responseBody.appendChild(formatter.render())
+            } catch (err) {
+              responseBody.innerText = body
+            }
+          })
+          .catch(err => {
+            responseHeader.innerHTML = 'Something went wront. Open the developer console.'
+            console.error(err)
+          })
+      })
+    </script>
+
+    <!-- Footer -->
+    <%- include('layout-footer') -%>
+  </body>
+</html>

--- a/views/dashboard/layout-header-api.ejs
+++ b/views/dashboard/layout-header-api.ejs
@@ -15,6 +15,9 @@
         <li class="<%= active === 'authentications' ? 'active' : '' %>">
           <a href="<%= base %>/authentications">Authentications</a>
         </li>
+        <li class="<%= active === 'request' ? 'active' : '' %>">
+          <a href="<%= base %>/request">Request</a>
+        </li>
         <li class="<%= active === 'monitoring' ? 'active' : '' %>">
           <a href="<%= base %>/monitoring">Monitoring</a>
         </li>


### PR DESCRIPTION
# Description

Made it easy to request an API right from the dashboard (without having to create a `cURL` or something). No support of `body` or headers here. I tried to make it easy, but we could probably add that in a later PR.

Here's a screnshot of how it look:

![Screenshot 2020-06-03 at 16 25 23](https://user-images.githubusercontent.com/3255133/83648864-d8506600-a5b6-11ea-8e57-f17c63dc296f.png)
