### PR TITLE
fix: enable cors on proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "compose-middleware": "^5.0.1",
     "connect-session-knex": "^1.6.0",
     "cookie-parser": "^1.4.3",
+    "cors": "^2.8.5",
     "ejs": "^3.0.2",
     "express": "^4.16.3",
     "express-session": "^1.15.6",

--- a/src/routes/proxy.ts
+++ b/src/routes/proxy.ts
@@ -6,6 +6,7 @@
  */
 
 import express from 'express'
+import cors from 'cors'
 import * as access from '../lib/access'
 import { incomingRequestHandler } from '../lib/proxy'
 import { asyncMiddleware } from '../lib/utils/asyncMiddleware'
@@ -36,6 +37,12 @@ proxy.use((req, res, next) => {
     return access.secretKey(req, res, next)
   }
 })
+
+/**
+ * Enable CORS on proxy requests
+ */
+
+proxy.use(cors())
 
 /**
  * Handle proxy requests.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1661,6 +1661,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -4951,7 +4959,7 @@ oauth@0.9.x, oauth@^0.9.15:
   resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.9.15.tgz#bd1fefaf686c96b75475aed5196412ff60cfb9c1"
   integrity sha1-vR/vr2hslrdUda7VGWQS/2DPucE=
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -7101,7 +7109,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
# Description

Enable all [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests on the proxy endpoint. This make the proxy reachable using Pizzly JS, when the Pizzly instance is not located on the same domain than the application.

You might need to update your CORS options to secure your instance. Have a look to the [CORS middleware](https://github.com/expressjs/cors) documentation to learn how to do it.