### PR TITLE
fix: no-default scope on integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,16 +127,16 @@ Here's an example with the GitHub configuration file ([`/integration/github.json
 ```json
 {
   "name": "GitHub",
-  "config": {
+  "auth": {
     "authorizationURL": "https://github.com/login/oauth/authorize",
     "tokenURL": "https://github.com/login/oauth/access_token",
     "authType": "OAUTH2",
     "tokenParams": {},
     "authorizationParams": {},
-    "config": { "accessType": "offline", "scope": [] }
+    "auth": { "accessType": "offline" }
   },
   "request": {
-    "baseURL": "https://api.github.com",
+    "baseURL": "https://api.github.com/",
     "headers": {
       "Accept": "application/vnd.github.v3+json",
       "Authorization": "token ${auth.accessToken}",

--- a/integrations/adobe-sign.json
+++ b/integrations/adobe-sign.json
@@ -12,7 +12,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/adobe-sign.json
+++ b/integrations/adobe-sign.json
@@ -1,15 +1,14 @@
 {
   "name": "Adobe Sign",
   "image": "https://logo.clearbit.com/adobe.com",
-  "config": {
+  "auth": {
     "authorizationURL": "https://secure.eu1.echosign.com/public/oauth",
     "tokenURL": "https://api.eu1.echosign.com/oauth/token",
     "refreshURL": "https://api.eu1.echosign.com/oauth/refresh",
-    "authType": "OAUTH2",
-    "config": { "scope": ["agreement_read:account"] }
+    "authType": "OAUTH2"
   },
   "request": {
-    "baseURL": "https://api.eu1.echosign.com/api/rest/v6",
+    "baseURL": "https://api.eu1.echosign.com/api/rest/v6/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/asana.json
+++ b/integrations/asana.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/asana.json
+++ b/integrations/asana.json
@@ -1,14 +1,12 @@
 {
   "name": "Asana",
-  "config": {
+  "auth": {
     "authorizationURL": "https://app.asana.com/-/oauth_authorize",
     "tokenURL": "https://app.asana.com/-/oauth_token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": { "response_type": "code", "scope": [] },
-    "provider": "Asana",
-    "hint": "You will find your Asana credentials here: https://app.asana.com"
+    "auth": { "response_type": "code" }
   },
   "request": {
     "baseURL": "https://app.asana.com/api/1.0/",

--- a/integrations/basecamp.json
+++ b/integrations/basecamp.json
@@ -16,7 +16,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/basecamp.json
+++ b/integrations/basecamp.json
@@ -1,6 +1,6 @@
 {
   "name": "Basecamp",
-  "config": {
+  "auth": {
     "authorizationURL": "https://launchpad.37signals.com/authorization/new",
     "tokenURL": "https://launchpad.37signals.com/authorization/token",
     "authType": "OAUTH2",
@@ -9,12 +9,10 @@
       "type": "web_server"
     },
     "authorizationParams": { "type": "web_server" },
-    "config": { "response_type": "code", "scope": [] },
-    "provider": "Basecamp",
-    "hint": "You will find your Basecamp credentials here: https://launchpad.37signals.com/integrations"
+    "auth": { "response_type": "code" }
   },
   "request": {
-    "baseURL": "https://3.basecampapi.com/${headers.basecamp_account_id}",
+    "baseURL": "https://3.basecampapi.com/${headers.basecamp_account_id}/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/bitbucket.json
+++ b/integrations/bitbucket.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/bitbucket.json
+++ b/integrations/bitbucket.json
@@ -1,14 +1,12 @@
 {
   "name": "BitBucket",
-  "config": {
+  "auth": {
     "authorizationURL": "https://bitbucket.org/site/oauth2/authorize",
     "tokenURL": "https://bitbucket.org/site/oauth2/access_token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": { "response_type": "code" },
-    "provider": "BitBucket",
-    "hint": "You will find your BitBucket credentials here: https://bitbucket.org/account/user/{username}/api"
+    "auth": { "response_type": "code" }
   },
   "request": {
     "baseURL": "https://api.bitbucket.org/2.0/",

--- a/integrations/cronofy.json
+++ b/integrations/cronofy.json
@@ -11,7 +11,7 @@
     "params": {},
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}"
     },
     "baseURL": "https://api.cronofy.com/v1/"

--- a/integrations/cronofy.json
+++ b/integrations/cronofy.json
@@ -1,8 +1,7 @@
 {
   "name": "Cronofy",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
-    "config": { "scope": ["read_write", "free_busy"] },
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "response_type": "code" },
     "authorizationURL": "https://app.cronofy.com/oauth/authorize",

--- a/integrations/docusign.json
+++ b/integrations/docusign.json
@@ -10,7 +10,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/docusign.json
+++ b/integrations/docusign.json
@@ -1,15 +1,12 @@
 {
   "name": "Docusign",
-  "config": {
+  "auth": {
     "authorizationURL": "https://account-d.docusign.com/oauth/auth",
     "tokenURL": "https://account-d.docusign.com/oauth/token",
-    "authType": "OAUTH2",
-    "config": { "scope": ["signature", "extended"] },
-    "provider": "DocuSign",
-    "hint": "You will find your DocuSign credentials here: https://admindemo.docusign.com/api-integrator-key"
+    "authType": "OAUTH2"
   },
   "request": {
-    "baseURL": "https://${headers.account_environment}.docusign.net/restapi/v2.1/accounts/${headers.account_id}",
+    "baseURL": "https://${headers.account_environment}.docusign.net/restapi/v2.1/accounts/${headers.account_id}/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/dropbox.json
+++ b/integrations/dropbox.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/dropbox.json
+++ b/integrations/dropbox.json
@@ -1,14 +1,12 @@
 {
   "name": "Dropbox",
-  "config": {
+  "auth": {
     "authorizationURL": "https://www.dropbox.com/oauth2/authorize",
     "tokenURL": "https://api.dropboxapi.com/oauth2/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": { "response_type": "code" },
-    "provider": "Dropbox",
-    "hint": "You will find your Dropbox credentials here: https://www.dropbox.com/developers/apps"
+    "auth": { "response_type": "code" }
   },
   "request": {
     "baseURL": "https://api.dropboxapi.com/2/",

--- a/integrations/eventbrite.json
+++ b/integrations/eventbrite.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/eventbrite.json
+++ b/integrations/eventbrite.json
@@ -1,14 +1,12 @@
 {
   "name": "Eventbrite",
-  "config": {
+  "auth": {
     "authorizationURL": "https://www.eventbrite.com/oauth/authorize",
     "tokenURL": "https://www.eventbrite.com/oauth/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": { "response_type": "code", "scope": [] },
-    "provider": "Eventbrite",
-    "hint": "You will find your Eventbrite credentials here: https://www.eventbrite.com/account-settings/apps"
+    "auth": { "response_type": "code" }
   },
   "request": {
     "baseURL": "https://www.eventbriteapi.com/v3/",

--- a/integrations/facebook.json
+++ b/integrations/facebook.json
@@ -15,7 +15,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/facebook.json
+++ b/integrations/facebook.json
@@ -1,6 +1,6 @@
 {
   "name": "Facebook",
-  "config": {
+  "auth": {
     "authorizationURL": "https://www.facebook.com/v3.2/dialog/oauth",
     "tokenURL": "https://graph.facebook.com/v3.2/oauth/access_token",
     "authType": "OAUTH2",
@@ -8,12 +8,10 @@
     "authorizationParams": {
       "state": "{st=state123abc,ds=123456789}"
     },
-    "config": { "response_type": "code", "scope": ["email"] },
-    "provider": "Facebook",
-    "hint": "You will find your Facebook credentials here: https://developers.facebook.com/apps/"
+    "auth": { "response_type": "code" }
   },
   "request": {
-    "baseURL": "https://graph.facebook.com",
+    "baseURL": "https://graph.facebook.com/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/freshbooks.json
+++ b/integrations/freshbooks.json
@@ -11,7 +11,7 @@
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
       "Api-Version": "alpha",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/freshbooks.json
+++ b/integrations/freshbooks.json
@@ -1,12 +1,9 @@
 {
   "name": "Freshbooks",
-  "config": {
+  "auth": {
     "authorizationURL": "https://my.freshbooks.com/service/auth/oauth/authorize",
     "tokenURL": "https://api.freshbooks.com/auth/oauth/token",
-    "authType": "OAUTH2",
-    "config": { "scope": [] },
-    "provider": "Freshbooks",
-    "hint": "You will find your Freshbooks credentials here: https://my.freshbooks.com/#/developer"
+    "authType": "OAUTH2"
   },
   "request": {
     "baseURL": "https://api.freshbooks.com/",

--- a/integrations/front.json
+++ b/integrations/front.json
@@ -1,9 +1,8 @@
 {
   "name": "Front",
   "image": "https://logo.clearbit.com/frontapp.com",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
-    "config": { "scope": [] },
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "response_type": "code" },
     "authorizationURL": "https://app.frontapp.com/oauth/authorize",
@@ -16,6 +15,6 @@
       "Authorization": "Bearer ${auth.accessToken}",
       "User-Agent": "Bearer.sh"
     },
-    "baseURL": "https://api2.frontapp.com"
+    "baseURL": "https://api2.frontapp.com/"
   }
 }

--- a/integrations/front.json
+++ b/integrations/front.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     },
     "baseURL": "https://api2.frontapp.com/"
   }

--- a/integrations/full-contact.json
+++ b/integrations/full-contact.json
@@ -15,7 +15,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/full-contact.json
+++ b/integrations/full-contact.json
@@ -1,17 +1,14 @@
 {
   "name": "FullContact",
-  "config": {
+  "auth": {
     "authorizationURL": "https://app.fullcontact.com/oauth/authorize",
     "tokenURL": "https://app.fullcontact.com/api/v1/oauth.exchangeAuthCode",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": {
-      "response_type": "code",
-      "scope": ["account.read"]
-    },
-    "provider": "FullContact",
-    "hint": "You will find your FullContact credentials here: https://app.contactsplus.com/apps"
+    "auth": {
+      "response_type": "code"
+    }
   },
   "request": {
     "baseURL": "https://app.fullcontact.com/api/v1/",

--- a/integrations/github.json
+++ b/integrations/github.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/vnd.github.v3+json",
       "Authorization": "token ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/github.json
+++ b/integrations/github.json
@@ -1,15 +1,15 @@
 {
   "name": "GitHub",
-  "config": {
+  "auth": {
     "authorizationURL": "https://github.com/login/oauth/authorize",
     "tokenURL": "https://github.com/login/oauth/access_token",
     "authType": "OAUTH2",
     "tokenParams": {},
     "authorizationParams": {},
-    "config": { "accessType": "offline", "scope": ["repo"] }
+    "auth": { "accessType": "offline" }
   },
   "request": {
-    "baseURL": "https://api.github.com",
+    "baseURL": "https://api.github.com/",
     "headers": {
       "Accept": "application/vnd.github.v3+json",
       "Authorization": "token ${auth.accessToken}",

--- a/integrations/gitlab.json
+++ b/integrations/gitlab.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/gitlab.json
+++ b/integrations/gitlab.json
@@ -1,14 +1,12 @@
 {
   "name": "GitLab",
-  "config": {
+  "auth": {
     "authorizationURL": "https://gitlab.com/oauth/authorize",
     "tokenURL": "https://gitlab.com/oauth/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": { "response_type": "code" },
-    "provider": "GitLab",
-    "hint": "You will find your GitLab credentials here: https://gitlab.com/oauth/applications"
+    "auth": { "response_type": "code" }
   },
   "request": {
     "baseURL": "https://gitlab.com/api/v4/",

--- a/integrations/google-calendar.json
+++ b/integrations/google-calendar.json
@@ -17,7 +17,7 @@
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
       "Content-Type": "application/json",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/google-calendar.json
+++ b/integrations/google-calendar.json
@@ -1,15 +1,14 @@
 {
   "name": "Google Calendar",
   "image": "https://upload.wikimedia.org/wikipedia/commons/e/e9/Google_Calendar.png",
-  "config": {
+  "auth": {
     "authorizationURL": "https://accounts.google.com/o/oauth2/v2/auth",
     "tokenURL": "https://www.googleapis.com/oauth2/v4/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "prompt": "consent", "access_type": "offline" },
-    "config": {
-      "response_type": "code",
-      "scope": ["https://www.googleapis.com/auth/calendar.readonly"]
+    "auth": {
+      "response_type": "code"
     }
   },
   "request": {

--- a/integrations/google-contacts.json
+++ b/integrations/google-contacts.json
@@ -16,7 +16,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "GData-Version": "3.0"
     }
   }

--- a/integrations/google-contacts.json
+++ b/integrations/google-contacts.json
@@ -1,19 +1,18 @@
 {
   "name": "Google Contacts",
   "image": "https://upload.wikimedia.org/wikipedia/commons/9/93/Google_Contacts_icon.svg",
-  "config": {
+  "auth": {
     "authorizationURL": "https://accounts.google.com/o/oauth2/v2/auth",
     "tokenURL": "https://www.googleapis.com/oauth2/v4/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "prompt": "consent", "access_type": "offline" },
-    "config": {
-      "response_type": "code",
-      "scope": ["https://www.googleapis.com/auth/contacts.readonly"]
+    "auth": {
+      "response_type": "code"
     }
   },
   "request": {
-    "baseURL": "https://www.google.com/m8",
+    "baseURL": "https://www.google.com/m8/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/google-docs.json
+++ b/integrations/google-docs.json
@@ -16,7 +16,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/google-docs.json
+++ b/integrations/google-docs.json
@@ -1,15 +1,14 @@
 {
   "name": "Google Docs",
   "image": "https://upload.wikimedia.org/wikipedia/commons/a/a7/Google_Docs_logo.svg",
-  "config": {
+  "auth": {
     "authorizationURL": "https://accounts.google.com/o/oauth2/v2/auth",
     "tokenURL": "https://www.googleapis.com/oauth2/v4/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "prompt": "consent", "access_type": "offline" },
-    "config": {
-      "response_type": "code",
-      "scope": ["https://www.googleapis.com/auth/documents"]
+    "auth": {
+      "response_type": "code"
     }
   },
   "request": {

--- a/integrations/google-drive.json
+++ b/integrations/google-drive.json
@@ -16,7 +16,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/google-drive.json
+++ b/integrations/google-drive.json
@@ -1,18 +1,15 @@
 {
   "name": "Google Drive",
   "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/da/Google_Drive_logo.png/240px-Google_Drive_logo.png",
-  "config": {
+  "auth": {
     "authorizationURL": "https://accounts.google.com/o/oauth2/v2/auth",
     "tokenURL": "https://www.googleapis.com/oauth2/v4/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "prompt": "consent", "access_type": "offline" },
-    "config": {
-      "response_type": "code",
-      "scope": ["https://www.googleapis.com/auth/drive.readonly"]
-    },
-    "provider": "Google Drive",
-    "hint": "You will find your Google Drive credentials here: https://console.cloud.google.com/apis/credentials"
+    "auth": {
+      "response_type": "code"
+    }
   },
   "request": {
     "baseURL": "https://www.googleapis.com/drive/v3/",

--- a/integrations/google-mail.json
+++ b/integrations/google-mail.json
@@ -1,15 +1,14 @@
 {
   "name": "Gmail",
   "image": "https://upload.wikimedia.org/wikipedia/commons/4/45/New_Logo_Gmail.svg",
-  "config": {
+  "auth": {
     "authorizationURL": "https://accounts.google.com/o/oauth2/v2/auth",
     "tokenURL": "https://www.googleapis.com/oauth2/v4/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "prompt": "consent", "access_type": "offline" },
-    "config": {
-      "response_type": "code",
-      "scope": ["https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/gmail.metadata"]
+    "auth": {
+      "response_type": "code"
     }
   },
   "request": {

--- a/integrations/google-mail.json
+++ b/integrations/google-mail.json
@@ -16,7 +16,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/google-sheets.json
+++ b/integrations/google-sheets.json
@@ -17,7 +17,7 @@
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
       "Content-Type": "application/json",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/google-sheets.json
+++ b/integrations/google-sheets.json
@@ -1,19 +1,18 @@
 {
   "name": "Google Sheets",
   "image": "https://upload.wikimedia.org/wikipedia/commons/1/11/Google-Sheets-Logo-2019.png",
-  "config": {
+  "auth": {
     "authorizationURL": "https://accounts.google.com/o/oauth2/v2/auth",
     "tokenURL": "https://www.googleapis.com/oauth2/v4/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "prompt": "consent", "access_type": "offline" },
-    "config": {
-      "response_type": "code",
-      "scope": ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+    "auth": {
+      "response_type": "code"
     }
   },
   "request": {
-    "baseURL": "https://sheets.googleapis.com/v4/spreadsheets",
+    "baseURL": "https://sheets.googleapis.com/v4/spreadsheets/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/hootsuite.json
+++ b/integrations/hootsuite.json
@@ -1,14 +1,12 @@
 {
   "name": "Hootsuite",
-  "config": {
+  "auth": {
     "authorizationURL": "https://platform.hootsuite.com/oauth2/auth",
     "tokenURL": "https://platform.hootsuite.com/oauth2/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": { "response_type": "code" },
-    "provider": "Hootsuite",
-    "hint": "You will find your Hootsuite credentials here: https://hootsuite.com/developers/my-apps/app-directory/app"
+    "auth": { "response_type": "code" }
   },
   "request": {
     "baseURL": "https://platform.hootsuite.com/v1/",

--- a/integrations/hootsuite.json
+++ b/integrations/hootsuite.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/hubspot.json
+++ b/integrations/hubspot.json
@@ -15,7 +15,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/hubspot.json
+++ b/integrations/hubspot.json
@@ -1,20 +1,17 @@
 {
   "name": "Hubspot",
-  "config": {
+  "auth": {
     "authorizationURL": "https://app.hubspot.com/oauth/authorize",
     "tokenURL": "https://api.hubapi.com/oauth/v1/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": {
-      "response_type": "code",
-      "scope": ["contacts"]
-    },
-    "provider": "Hubspot",
-    "hint": "You will find your Hubspot credentials here: https://app.hubspot.com"
+    "auth": {
+      "response_type": "code"
+    }
   },
   "request": {
-    "baseURL": "https://api.hubapi.com",
+    "baseURL": "https://api.hubapi.com/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/imgur.json
+++ b/integrations/imgur.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/imgur.json
+++ b/integrations/imgur.json
@@ -1,14 +1,12 @@
 {
   "name": "imgur",
-  "config": {
+  "auth": {
     "authorizationURL": "https://api.imgur.com/oauth2/authorize",
     "tokenURL": "https://api.imgur.com/oauth2/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": { "response_type": "code" },
-    "provider": "imgur",
-    "hint": "You will find your imgur credentials here: https://api.imgur.com/oauth2/addclient"
+    "auth": { "response_type": "code" }
   },
   "request": {
     "baseURL": "https://api.imgur.com/3/",

--- a/integrations/intercom.json
+++ b/integrations/intercom.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/intercom.json
+++ b/integrations/intercom.json
@@ -1,14 +1,12 @@
 {
   "name": "Intercom",
-  "config": {
+  "auth": {
     "authorizationURL": "https://app.intercom.io/oauth",
     "tokenURL": "https://api.intercom.io/auth/eagle/token",
     "authType": "OAUTH2",
     "tokenParams": {},
     "authorizationParams": {},
-    "config": { "response_type": "code", "scope": [] },
-    "provider": "Intercom",
-    "hint": "You will find your Intercom credentials here: https://app.intercom.com/a/apps/_/developer-hub"
+    "auth": { "response_type": "code" }
   },
   "request": {
     "baseURL": "https://api.intercom.io/",

--- a/integrations/jira.json
+++ b/integrations/jira.json
@@ -16,7 +16,7 @@
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
       "Content-Type": "application/json",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/jira.json
+++ b/integrations/jira.json
@@ -1,17 +1,14 @@
 {
   "name": "Jira",
-  "config": {
+  "auth": {
     "authorizationURL": "https://auth.atlassian.com/authorize",
     "tokenURL": "https://auth.atlassian.com/oauth/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "prompt": "consent", "state": 1, "audience": "api.atlassian.com" },
-    "config": {
-      "response_type": "code",
-      "scope": ["read:jira-work"]
-    },
-    "provider": "Jira",
-    "hint": "You will find your Jira credentials here: https://developer.atlassian.com/apps/create"
+    "auth": {
+      "response_type": "code"
+    }
   },
   "request": {
     "baseURL": "https://${headers.atlassian_domain}.atlassian.net/rest/api/3/",

--- a/integrations/linkedin.json
+++ b/integrations/linkedin.json
@@ -15,7 +15,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/linkedin.json
+++ b/integrations/linkedin.json
@@ -1,20 +1,17 @@
 {
   "name": "Linkedin",
-  "config": {
+  "auth": {
     "authorizationURL": "https://www.linkedin.com/oauth/v2/authorization",
     "tokenURL": "https://www.linkedin.com/oauth/v2/accessToken",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": {
-      "response_type": "code",
-      "scope": ["r_liteprofile"]
-    },
-    "provider": "Linkedin",
-    "hint": "You will find your LinkedIn credentials here: https://www.linkedin.com/developers/apps"
+    "auth": {
+      "response_type": "code"
+    }
   },
   "request": {
-    "baseURL": "https://api.linkedin.com/v2",
+    "baseURL": "https://api.linkedin.com/v2/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/microsoft-one-drive.json
+++ b/integrations/microsoft-one-drive.json
@@ -1,14 +1,13 @@
 {
   "name": "Microsoft OneDrive",
   "image": "https://upload.wikimedia.org/wikipedia/commons/d/d3/Microsoft_Office_OneDrive_%282018%E2%80%93present%29.svg",
-  "config": {
+  "auth": {
     "authorizationURL": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     "tokenURL": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-    "authType": "OAUTH2",
-    "config": { "scope": ["Files.ReadWrite.All", "offline_access"] }
+    "authType": "OAUTH2"
   },
   "request": {
-    "baseURL": "https://graph.microsoft.com/v1.0",
+    "baseURL": "https://graph.microsoft.com/v1.0/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/microsoft-one-drive.json
+++ b/integrations/microsoft-one-drive.json
@@ -11,7 +11,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/microsoft-one-note.json
+++ b/integrations/microsoft-one-note.json
@@ -1,14 +1,13 @@
 {
   "name": "Microsoft OneNote",
   "image": "https://upload.wikimedia.org/wikipedia/commons/1/1c/Microsoft_Office_OneNote_%282018%E2%80%93present%29.svg",
-  "config": {
+  "auth": {
     "authorizationURL": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     "tokenURL": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-    "authType": "OAUTH2",
-    "config": { "scope": ["Notes.Read", "Notes.Read.All", "offline_access"] }
+    "authType": "OAUTH2"
   },
   "request": {
-    "baseURL": "https://graph.microsoft.com/v1.0",
+    "baseURL": "https://graph.microsoft.com/v1.0/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/microsoft-one-note.json
+++ b/integrations/microsoft-one-note.json
@@ -11,7 +11,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/microsoft-teams.json
+++ b/integrations/microsoft-teams.json
@@ -11,7 +11,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/microsoft-teams.json
+++ b/integrations/microsoft-teams.json
@@ -1,11 +1,10 @@
 {
   "name": "Microsoft Teams",
   "image": "https://upload.wikimedia.org/wikipedia/commons/c/c9/Microsoft_Office_Teams_%282018%E2%80%93present%29.svg",
-  "config": {
+  "auth": {
     "authorizationURL": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     "tokenURL": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-    "authType": "OAUTH2",
-    "config": { "scope": ["openid", "offline_access", "https://graph.microsoft.com/user.read"] }
+    "authType": "OAUTH2"
   },
   "request": {
     "baseURL": "https://graph.microsoft.com/v1.0/",

--- a/integrations/moltin.json
+++ b/integrations/moltin.json
@@ -1,6 +1,6 @@
 {
   "name": "Moltin",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
     "bodyFormat": "form",
     "tokenParams": { "grant_type": "client_credentials" },

--- a/integrations/moltin.json
+++ b/integrations/moltin.json
@@ -11,7 +11,7 @@
     "params": {},
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}"
     },
     "baseURL": "https://api.moltin.com/v2/"

--- a/integrations/online.json
+++ b/integrations/online.json
@@ -1,16 +1,15 @@
 {
   "name": "Scaleway",
   "image": "https://logo.clearbit.com/scaleway.com",
-  "config": {
+  "auth": {
     "authorizationURL": "https://console.online.net/oauth/v2/auth",
     "tokenURL": "https://console.online.net/oauth/v2/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
-    "authorizationParams": { "state": 1 },
-    "config": { "scope": [] }
+    "authorizationParams": { "state": 1 }
   },
   "request": {
-    "baseURL": "https://api.online.net/api/v1",
+    "baseURL": "https://api.online.net/api/v1/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/online.json
+++ b/integrations/online.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/pinterest.json
+++ b/integrations/pinterest.json
@@ -1,17 +1,14 @@
 {
   "name": "Pinterest",
-  "config": {
+  "auth": {
     "authorizationURL": " https://api.pinterest.com/oauth/",
     "tokenURL": "https://api.pinterest.com/v1/oauth/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": {
-      "response_type": "code",
-      "scope": ["read_public"]
-    },
-    "provider": "Pinterest",
-    "hint": "You will find your Pinterest credentials here: https://developers.pinterest.com/apps/5032758929927488034/"
+    "auth": {
+      "response_type": "code"
+    }
   },
   "request": {
     "baseURL": "https://api.pinterest.com/v1/",

--- a/integrations/pinterest.json
+++ b/integrations/pinterest.json
@@ -12,7 +12,7 @@
   },
   "request": {
     "baseURL": "https://api.pinterest.com/v1/",
-    "headers": { "Accept": "application/json", "User-Agent": "Bearer.sh" },
+    "headers": { "Accept": "application/json", "User-Agent": "Pizzly" },
     "params": { "access_token": "${auth.accessToken}" }
   }
 }

--- a/integrations/product-hunt.json
+++ b/integrations/product-hunt.json
@@ -1,17 +1,15 @@
 {
   "name": "Product Hunt",
-  "config": {
+  "auth": {
     "authorizationURL": "https://api.producthunt.com/v2/oauth/authorize",
     "tokenURL": "https://api.producthunt.com/v2/oauth/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": { "response_type": "code", "scope": ["public"] },
-    "provider": "Product Hunt",
-    "hint": "You will find your Product Hunt API Key here: https://www.producthunt.com/v2/oauth/applications"
+    "auth": { "response_type": "code" }
   },
   "request": {
-    "baseURL": "https://api.producthunt.com/v2/api",
+    "baseURL": "https://api.producthunt.com/v2/api/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/product-hunt.json
+++ b/integrations/product-hunt.json
@@ -13,7 +13,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/quickbooks-sandbox.json
+++ b/integrations/quickbooks-sandbox.json
@@ -17,7 +17,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/quickbooks-sandbox.json
+++ b/integrations/quickbooks-sandbox.json
@@ -1,22 +1,19 @@
 {
   "name": "Quickbooks Sandbox",
   "image": "http://logo.clearbit.com/quickbooks.com",
-  "config": {
+  "auth": {
     "authorizationURL": "https://appcenter.intuit.com/connect/oauth2",
     "tokenURL": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": {
+    "auth": {
       "response_type": "code",
-      "scope": ["com.intuit.quickbooks.accounting", "com.intuit.quickbooks.payment", "openid"],
       "state": "test"
-    },
-    "provider": "Quickbooks",
-    "hint": "You will find your Quickbooks credentials here: https://developer.intuit.com/v2/ui#/app/dashboard"
+    }
   },
   "request": {
-    "baseURL": "https://sandbox-quickbooks.api.intuit.com/v3/company/${auth.idTokenJwt.realmid}",
+    "baseURL": "https://sandbox-quickbooks.api.intuit.com/v3/company/${auth.idTokenJwt.realmid}/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/quickbooks.json
+++ b/integrations/quickbooks.json
@@ -16,7 +16,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/quickbooks.json
+++ b/integrations/quickbooks.json
@@ -1,21 +1,18 @@
 {
   "name": "Quickbooks",
-  "config": {
+  "auth": {
     "authorizationURL": "https://appcenter.intuit.com/connect/oauth2",
     "tokenURL": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": {
+    "auth": {
       "response_type": "code",
-      "scope": ["com.intuit.quickbooks.accounting", "com.intuit.quickbooks.payment", "openid"],
       "state": "test"
-    },
-    "provider": "Quickbooks",
-    "hint": "You will find your Quickbooks credentials here: https://developer.intuit.com/v2/ui#/app/dashboard"
+    }
   },
   "request": {
-    "baseURL": "https://quickbooks.api.intuit.com/v3/company/${auth.idTokenJwt.realmid}",
+    "baseURL": "https://quickbooks.api.intuit.com/v3/company/${auth.idTokenJwt.realmid}/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/reddit.json
+++ b/integrations/reddit.json
@@ -1,16 +1,15 @@
 {
   "name": "Reddit",
-  "config": {
+  "auth": {
     "authorizationURL": "https://www.reddit.com/api/v1/authorize",
     "tokenURL": "https://www.reddit.com/api/v1/access_token",
     "authType": "OAUTH2",
     "tokenParams": {},
     "authorizationParams": {},
-    "config": { "scope": ["read"] },
     "authorizationMethod": "header"
   },
   "request": {
-    "baseURL": "https://oauth.reddit.com",
+    "baseURL": "https://oauth.reddit.com/",
     "headers": {
       "Accept": "application/json",
       "User-Agent": "Bearer.sh",

--- a/integrations/reddit.json
+++ b/integrations/reddit.json
@@ -12,7 +12,7 @@
     "baseURL": "https://oauth.reddit.com/",
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}"
     },
     "params": {}

--- a/integrations/revolut-sandbox.json
+++ b/integrations/revolut-sandbox.json
@@ -1,9 +1,8 @@
 {
   "name": "Revolut (sandbox)",
   "image": "http://logo.clearbit.com/revolut.com",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
-    "config": { "scope": ["READ"] },
     "tokenParams": { "response_type": "code" },
     "authorizationParams": {},
     "authorizationURL": "https://sandbox-business.revolut.com/app-confirm",

--- a/integrations/revolut-sandbox.json
+++ b/integrations/revolut-sandbox.json
@@ -12,7 +12,7 @@
     "params": {},
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}"
     },
     "baseURL": "https://sandbox-b2b.revolut.com/api/1.0/"

--- a/integrations/salesforce.json
+++ b/integrations/salesforce.json
@@ -12,7 +12,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/salesforce.json
+++ b/integrations/salesforce.json
@@ -1,12 +1,11 @@
 {
   "name": "Salesforce",
-  "config": {
+  "auth": {
     "authorizationURL": "https://login.salesforce.com/services/oauth2/authorize",
     "tokenURL": "https://login.salesforce.com/services/oauth2/token",
     "authType": "OAUTH2",
     "tokenParams": {},
-    "authorizationParams": {},
-    "config": { "scope": [] }
+    "authorizationParams": {}
   },
   "request": {
     "baseURL": "${auth.tokenResponse.body.instance_url}/services/",

--- a/integrations/sellsy.json
+++ b/integrations/sellsy.json
@@ -12,6 +12,6 @@
   },
   "request": {
     "baseURL": "https://apifeed.sellsy.fr/0/",
-    "headers": { "Accept": "application/json", "Authorization": "OAuth ${auth.oauth1}", "User-Agent": "Bearer.sh" }
+    "headers": { "Accept": "application/json", "Authorization": "OAuth ${auth.oauth1}", "User-Agent": "Pizzly" }
   }
 }

--- a/integrations/sellsy.json
+++ b/integrations/sellsy.json
@@ -1,6 +1,6 @@
 {
   "name": "Sellsy",
-  "config": {
+  "auth": {
     "requestTokenURL": "https://apifeed.sellsy.com/0/request_token",
     "accessTokenURL": "https://apifeed.sellsy.com/0/access_token",
     "userAuthorizationURL": "https://apifeed.sellsy.com/0/login.php",
@@ -8,9 +8,7 @@
     "signatureMethod": "PLAINTEXT",
     "tokenParams": {},
     "authorizationParams": {},
-    "config": {},
-    "provider": "Sellsy",
-    "hint": "You will find your Sellsy credentials here: https://www.sellsy.com/?_f=accountPreferences\\u0026action=development"
+    "auth": {}
   },
   "request": {
     "baseURL": "https://apifeed.sellsy.fr/0/",

--- a/integrations/shopify.json
+++ b/integrations/shopify.json
@@ -1,13 +1,12 @@
 {
   "name": "Shopify",
-  "config": {
+  "auth": {
     "authorizationURL": "https://${connectParams.shop}.myshopify.com/admin/oauth/authorize",
     "authType": "OAUTH2",
-    "config": { "scope": ["read_products"] },
     "tokenURL": "https://${connectParams.shop}.myshopify.com/admin/oauth/access_token"
   },
   "request": {
-    "baseURL": "https://${connectParams.shop}.myshopify.com/admin/api",
+    "baseURL": "https://${connectParams.shop}.myshopify.com/admin/api/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/shopify.json
+++ b/integrations/shopify.json
@@ -10,7 +10,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     },
     "params": {}
   }

--- a/integrations/slack.json
+++ b/integrations/slack.json
@@ -14,7 +14,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/slack.json
+++ b/integrations/slack.json
@@ -1,13 +1,12 @@
 {
   "name": "Slack",
-  "config": {
+  "auth": {
     "authorizationURL": "https://slack.com/oauth/authorize",
     "tokenURL": "https://slack.com/api/oauth.access",
     "authType": "OAUTH2",
     "authorizationParams": { "access_type": "offline", "consent": true },
-    "config": {
-      "accessType": "offline",
-      "scope": ["reminders:write"]
+    "auth": {
+      "accessType": "offline"
     }
   },
   "request": {

--- a/integrations/snov.json
+++ b/integrations/snov.json
@@ -12,7 +12,7 @@
   "request": {
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}"
     },
     "baseURL": "https://app.snov.io/restapi/",

--- a/integrations/snov.json
+++ b/integrations/snov.json
@@ -1,10 +1,9 @@
 {
   "name": "Snov.io",
   "image": "https://logo.clearbit.com/snov.io",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
     "bodyFormat": "form",
-    "config": { "scope": [] },
     "tokenParams": { "grant_type": "client_credentials" },
     "tokenURL": "https://app.snov.io/oauth/access_token",
     "authorizationMethod": "body",

--- a/integrations/survey-monkey.json
+++ b/integrations/survey-monkey.json
@@ -15,7 +15,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/survey-monkey.json
+++ b/integrations/survey-monkey.json
@@ -1,20 +1,17 @@
 {
   "name": "Survey Monkey",
-  "config": {
+  "auth": {
     "authorizationURL": "https://api.surveymonkey.com/oauth/authorize",
     "tokenURL": "https://api.surveymonkey.com/oauth/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": {
-      "response_type": "code",
-      "scope": ["users_read"]
-    },
-    "provider": "Survey Monkey",
-    "hint": "You will find your Survey Monkey credentials here: https://developer.surveymonkey.com/apps/"
+    "auth": {
+      "response_type": "code"
+    }
   },
   "request": {
-    "baseURL": "https://api.surveymonkey.com/v3",
+    "baseURL": "https://api.surveymonkey.com/v3/",
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",

--- a/integrations/todoist.json
+++ b/integrations/todoist.json
@@ -1,17 +1,14 @@
 {
   "name": "Todoist",
-  "config": {
+  "auth": {
     "authorizationURL": "https://todoist.com/oauth/authorize",
     "tokenURL": "https://todoist.com/oauth/access_token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": {
-      "response_type": "code",
-      "scope": ["data:read"]
-    },
-    "provider": "Todoist",
-    "hint": "You will find your Todoist credentials here: https://developer.todoist.com/appconsole.html"
+    "auth": {
+      "response_type": "code"
+    }
   },
   "request": {
     "baseURL": "https://todoist.com/api/v8/",

--- a/integrations/todoist.json
+++ b/integrations/todoist.json
@@ -12,7 +12,7 @@
   },
   "request": {
     "baseURL": "https://todoist.com/api/v8/",
-    "headers": { "Accept": "application/json", "User-Agent": "Bearer.sh" },
+    "headers": { "Accept": "application/json", "User-Agent": "Pizzly" },
     "params": { "token": "${auth.accessToken}" }
   }
 }

--- a/integrations/trello.json
+++ b/integrations/trello.json
@@ -11,7 +11,7 @@
   },
   "request": {
     "baseURL": "https://api.trello.com/1/",
-    "headers": { "Accept": "application/json", "User-Agent": "Bearer.sh" },
+    "headers": { "Accept": "application/json", "User-Agent": "Pizzly" },
     "params": { "key": "${auth.consumerKey}", "token": "${auth.accessToken}" }
   }
 }

--- a/integrations/trello.json
+++ b/integrations/trello.json
@@ -1,16 +1,13 @@
 {
   "name": "Trello",
-  "config": {
+  "auth": {
     "requestTokenURL": "https://trello.com/1/OAuthGetRequestToken",
     "accessTokenURL": "https://trello.com/1/OAuthGetAccessToken",
     "userAuthorizationURL": "https://trello.com/1/OAuthAuthorizeToken",
     "authType": "OAUTH1",
     "signatureMethod": "HMAC-SHA1",
     "tokenParams": {},
-    "authorizationParams": { "expiration": "never" },
-    "config": { "scope": ["read"] },
-    "provider": "Trello",
-    "hint": "You will find your Trello credentials here: https://trello.com/app-key"
+    "authorizationParams": { "expiration": "never" }
   },
   "request": {
     "baseURL": "https://api.trello.com/1/",

--- a/integrations/twist.json
+++ b/integrations/twist.json
@@ -1,8 +1,7 @@
 {
   "name": "Twist",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
-    "config": { "scope": ["workspaces:read"] },
     "tokenParams": {},
     "authorizationParams": {},
     "authorizationURL": "https://twist.com/oauth/authorize",

--- a/integrations/twist.json
+++ b/integrations/twist.json
@@ -11,7 +11,7 @@
     "params": {},
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}"
     },
     "baseURL": "https://api.twist.com/api/v3"

--- a/integrations/twitch.json
+++ b/integrations/twitch.json
@@ -13,7 +13,7 @@
     "params": {},
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}"
     },
     "baseURL": "https://api.twitch.tv/helix/"

--- a/integrations/twitch.json
+++ b/integrations/twitch.json
@@ -1,9 +1,8 @@
 {
   "name": "Twitch",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
     "bodyFormat": "form",
-    "config": { "scope": ["user:read:email"] },
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationMethod": "body",
     "authorizationParams": { "responseType": "code" },

--- a/integrations/twitter.json
+++ b/integrations/twitter.json
@@ -11,6 +11,6 @@
   },
   "request": {
     "baseURL": "https://api.twitter.com/1.1/",
-    "headers": { "Accept": "application/json", "Authorization": "OAuth ${auth.oauth1}", "User-Agent": "Bearer.sh" }
+    "headers": { "Accept": "application/json", "Authorization": "OAuth ${auth.oauth1}", "User-Agent": "Pizzly" }
   }
 }

--- a/integrations/twitter.json
+++ b/integrations/twitter.json
@@ -1,14 +1,13 @@
 {
   "name": "Twitter",
-  "config": {
+  "auth": {
     "requestTokenURL": "https://api.twitter.com/oauth/request_token",
     "accessTokenURL": "https://api.twitter.com/oauth/access_token",
     "userAuthorizationURL": "https://api.twitter.com/oauth/authorize",
     "authType": "OAUTH1",
     "signatureMethod": "HMAC-SHA1",
     "tokenParams": {},
-    "authorizationParams": {},
-    "config": { "scope": ["read"] }
+    "authorizationParams": {}
   },
   "request": {
     "baseURL": "https://api.twitter.com/1.1/",

--- a/integrations/typeform.json
+++ b/integrations/typeform.json
@@ -15,7 +15,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/typeform.json
+++ b/integrations/typeform.json
@@ -1,17 +1,14 @@
 {
   "name": "Typeform",
-  "config": {
+  "auth": {
     "authorizationURL": "https://api.typeform.com/oauth/authorize",
     "tokenURL": "https://api.typeform.com/oauth/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": {
-      "scope": ["forms:read"],
+    "auth": {
       "response_type": "code"
-    },
-    "provider": "Typeform",
-    "hint": "You will find your Typeform credentials here: https://admin.typeform.com/account#/section/apps"
+    }
   },
   "request": {
     "baseURL": "https://api.typeform.com/",

--- a/integrations/unsplash.json
+++ b/integrations/unsplash.json
@@ -1,8 +1,7 @@
 {
   "name": "Unsplash",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
-    "config": { "scope": ["public read_user read_collections"] },
     "tokenParams": {},
     "authorizationParams": {},
     "authorizationURL": "https://unsplash.com/oauth/authorize",
@@ -14,6 +13,6 @@
       "User-Agent": "Bearer.sh",
       "Authorization": "Bearer ${auth.accessToken}"
     },
-    "baseURL": "https://api.unsplash.com"
+    "baseURL": "https://api.unsplash.com/"
   }
 }

--- a/integrations/unsplash.json
+++ b/integrations/unsplash.json
@@ -10,7 +10,7 @@
   "request": {
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}"
     },
     "baseURL": "https://api.unsplash.com/"

--- a/integrations/whatsapp.json
+++ b/integrations/whatsapp.json
@@ -1,6 +1,6 @@
 {
   "name": "WhatsApp",
-  "config": {
+  "auth": {
     "authorizationURL": "https://www.facebook.com/v3.2/dialog/oauth",
     "tokenURL": "https://graph.facebook.com/v3.2/oauth/access_token",
     "authType": "OAUTH2",
@@ -8,12 +8,9 @@
     "authorizationParams": {
       "state": "{st=state123abc,ds=123456789}"
     },
-    "config": {
-      "response_type": "code",
-      "scope": ["whatsapp_business_management"]
-    },
-    "provider": "WhatsApp",
-    "hint": "You will find your WhatsApp credentials here: https://developers.facebook.com/apps/"
+    "auth": {
+      "response_type": "code"
+    }
   },
   "request": {
     "baseURL": "https://graph.facebook.com/v3.3",

--- a/integrations/whatsapp.json
+++ b/integrations/whatsapp.json
@@ -17,7 +17,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/xero.json
+++ b/integrations/xero.json
@@ -11,6 +11,6 @@
   },
   "request": {
     "baseURL": "https://api.xero.com/api.xro/2.0/",
-    "headers": { "Accept": "application/json", "Authorization": "OAuth ${auth.oauth1}", "User-Agent": "Bearer.sh" }
+    "headers": { "Accept": "application/json", "Authorization": "OAuth ${auth.oauth1}", "User-Agent": "Pizzly" }
   }
 }

--- a/integrations/xero.json
+++ b/integrations/xero.json
@@ -1,12 +1,9 @@
 {
   "name": "Xero",
-  "config": {
+  "auth": {
     "accessTokenURL": "https://api.xero.com/oauth/AccessToken",
     "authorizationParams": {},
     "authType": "OAUTH1",
-    "config": { "scope": [] },
-    "hint": "You will find your Xero credentials here: https://developer.xero.com/myapps",
-    "provider": "Xero",
     "requestTokenURL": "https://api.xero.com/oauth/RequestToken",
     "signatureMethod": "HMAC-SHA1",
     "tokenParams": {},

--- a/integrations/youtube.json
+++ b/integrations/youtube.json
@@ -15,7 +15,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/youtube.json
+++ b/integrations/youtube.json
@@ -1,17 +1,14 @@
 {
   "name": "YouTube",
-  "config": {
+  "auth": {
     "authorizationURL": "https://accounts.google.com/o/oauth2/v2/auth",
     "tokenURL": "https://www.googleapis.com/oauth2/v4/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "prompt": "consent", "access_type": "offline" },
-    "config": {
-      "response_type": "code",
-      "scope": ["https://www.googleapis.com/auth/youtube"]
-    },
-    "provider": "Youtube",
-    "hint": "You will find your Youtube credentials here: https://console.cloud.google.com/apis/credentials"
+    "auth": {
+      "response_type": "code"
+    }
   },
   "request": {
     "baseURL": "https://www.googleapis.com/youtube/v3/",

--- a/integrations/zendesk-chat.json
+++ b/integrations/zendesk-chat.json
@@ -1,8 +1,7 @@
 {
   "name": "Zendesk Chat",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
-    "config": { "scope": ["read", "write", "chat"] },
     "tokenParams": {},
     "authorizationParams": {
       "response_type": "token",

--- a/integrations/zendesk-chat.json
+++ b/integrations/zendesk-chat.json
@@ -14,7 +14,7 @@
     "params": {},
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}"
     },
     "baseURL": "https://www.zopim.com/api/v2/"

--- a/integrations/zoho-books.json
+++ b/integrations/zoho-books.json
@@ -13,7 +13,7 @@
   "request": {
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Zoho-oauthtoken ${auth.accessToken}"
     },
     "baseURL": "https://books.zoho.com/api/v3/"

--- a/integrations/zoho-books.json
+++ b/integrations/zoho-books.json
@@ -1,10 +1,9 @@
 {
   "name": "Zoho Books",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
-    "config": {
-      "response_type": "code",
-      "scope": ["ZohoBooks.contacts.READ"]
+    "auth": {
+      "response_type": "code"
     },
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "access_type": "offline", "prompt": "consent" },

--- a/integrations/zoho-crm.json
+++ b/integrations/zoho-crm.json
@@ -12,7 +12,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/zoho-crm.json
+++ b/integrations/zoho-crm.json
@@ -1,14 +1,11 @@
 {
   "name": "Zoho CRM",
-  "config": {
+  "auth": {
     "authorizationURL": "https://accounts.zoho.com/oauth/v2/auth",
     "tokenURL": "https://accounts.zoho.com/oauth/v2/token",
     "authType": "OAUTH2",
     "tokenParams": {},
-    "authorizationParams": { "access_type": "offline", "prompt": "consent" },
-    "config": { "scope": ["ZohoCRM.users.ALL"] },
-    "provider": "Zoho CRM",
-    "hint": "You will find your Zoho CRM credentials here: https://accounts.zoho.com/developerconsole"
+    "authorizationParams": { "access_type": "offline", "prompt": "consent" }
   },
   "request": {
     "baseURL": "https://www.zohoapis.com/crm/v2",

--- a/integrations/zoho-invoices.json
+++ b/integrations/zoho-invoices.json
@@ -1,8 +1,8 @@
 {
   "name": "Zoho Invoice",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
-    "config": { "response_type": "code" },
+    "auth": { "response_type": "code" },
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "access_type": "offline", "prompt": "consent" },
     "authorizationURL": "https://accounts.zoho.com/oauth/v2/auth",

--- a/integrations/zoho-invoices.json
+++ b/integrations/zoho-invoices.json
@@ -11,7 +11,7 @@
   "request": {
     "headers": {
       "Accept": "application/json",
-      "User-Agent": "Bearer.sh",
+      "User-Agent": "Pizzly",
       "Authorization": "Zoho-oauthtoken ${auth.accessToken}"
     },
     "baseURL": "https://invoice.zoho.com/api/v3/"

--- a/integrations/zoho-subscriptions.json
+++ b/integrations/zoho-subscriptions.json
@@ -14,7 +14,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     },
     "baseURL": "https://subscriptions.zoho.com/api/v1/"
   }

--- a/integrations/zoho-subscriptions.json
+++ b/integrations/zoho-subscriptions.json
@@ -1,10 +1,9 @@
 {
   "name": "Zoho Subscriptions",
-  "config": {
+  "auth": {
     "authType": "OAUTH2",
-    "config": {
-      "response_type": "code",
-      "scope": ["ZohoSubscriptions.products.READ"]
+    "auth": {
+      "response_type": "code"
     },
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": { "access_type": "offline", "prompt": "consent" },

--- a/integrations/zoom.json
+++ b/integrations/zoom.json
@@ -15,7 +15,7 @@
     "headers": {
       "Accept": "application/json",
       "Authorization": "Bearer ${auth.accessToken}",
-      "User-Agent": "Bearer.sh"
+      "User-Agent": "Pizzly"
     }
   }
 }

--- a/integrations/zoom.json
+++ b/integrations/zoom.json
@@ -1,14 +1,13 @@
 {
   "name": "Zoom",
-  "config": {
+  "auth": {
     "authorizationURL": "https://zoom.us/oauth/authorize",
     "tokenURL": "https://zoom.us/oauth/token",
     "authType": "OAUTH2",
     "tokenParams": { "grant_type": "authorization_code" },
     "authorizationParams": {},
-    "config": {
-      "response_type": "code",
-      "scope": ["chat_channel:read"]
+    "auth": {
+      "response_type": "code"
     }
   },
   "request": {

--- a/src/legacy/auth/clients/integrations.ts
+++ b/src/legacy/auth/clients/integrations.ts
@@ -85,12 +85,12 @@ export const getConfig = async ({ buid }: { buid: string }) => {
     }
   }
 
-  const configItem = item.config as TIntegrationConfig
+  const configItem = item.auth as TIntegrationConfig
   if (configItem.authType) {
     configItem.authType = configItem.authType.toUpperCase() as EAuthType
   }
 
-  return { ...configItem, requestConfig: item.request }
+  return { ...configItem, authConfig: configItem, requestConfig: item.request }
 }
 
 export const saveSetupDetails = async ({

--- a/src/legacy/auth/clients/oauth2.test.ts
+++ b/src/legacy/auth/clients/oauth2.test.ts
@@ -66,7 +66,7 @@ const responseHeaders = { useful_header: 'abc' }
 
 const commonHeaders = {
   Accept: 'application/json',
-  'User-Agent': 'Bearer'
+  'User-Agent': 'Pizzly'
 }
 
 // mocked(inspectAccessToken).mockResolvedValue(undefined)

--- a/src/legacy/auth/clients/oauth2.ts
+++ b/src/legacy/auth/clients/oauth2.ts
@@ -8,7 +8,7 @@ import Boom from 'boom'
 import { OAuthTokenResponse } from '../v3/types'
 // import { inspectAccessToken } from './openid-connect'
 
-const headers = { 'User-Agent': 'Bearer' }
+const headers = {}
 
 const createClientForRedirect = ({ authorizationURL, clientId }: RedirectClientParams) => {
   const url = new URL(authorizationURL)

--- a/src/legacy/auth/v3/strategies/oauth1.test.ts
+++ b/src/legacy/auth/v3/strategies/oauth1.test.ts
@@ -50,7 +50,7 @@ describe('authenticate', () => {
     nock('https://example.com')
       .post('/requestToken', requestBody, {
         reqheaders: {
-          'User-Agent': 'Bearer',
+          'User-Agent': 'Pizzly',
           Authorization: new RegExp(
             'OAuth oauth_callback="https%3A%2F%2Fexample\\.com%2Fv2%2Fauth%2Fcallback",' +
               'oauth_consumer_key="test-consumer-key",oauth_nonce="w+",' +
@@ -111,7 +111,7 @@ describe('authenticate', () => {
     const mockAccessTokenReq = () =>
       nock('https://example.com').post('/accessToken', '', {
         reqheaders: {
-          'User-Agent': 'Bearer',
+          'User-Agent': 'Pizzly',
           Authorization: new RegExp(
             'OAuth oauth_consumer_key ="test-consumer-key",oauth_nonce="w+",' +
               'oauth_signature_method="PLAINTEXT",oauth_timestamp="d+",' +

--- a/src/lib/database/integrations.ts
+++ b/src/lib/database/integrations.ts
@@ -69,9 +69,6 @@ const formatIntegration = (fileName: string, fileContent: any) => {
   integration.id = fileName
   integration.image =
     integration.image || 'http://logo.clearbit.com/' + integration.name.toLowerCase().replace(' ', '') + '.com'
-  // Hack to prevent mix match things
-  // @ts-expect-error
-  integration.auth = integration.config
 
   const isOAuth2Auth = isOAuth2(integration)
   integration.auth.setupKeyLabel = isOAuth2Auth ? 'Client ID' : 'Consumer Key'

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -99,13 +99,13 @@ dashboard.get('/all', async (req, res) => {
 })
 
 dashboard.use('/:integration', async (req, res, next) => {
-  const api = await integrations.get(req.params.integration).catch(err => next(err))
+  const integration = await integrations.get(req.params.integration).catch(err => next(err))
 
   // @ts-ignore
   req.ejs = { ...req.ejs, base_url: `/dashboard/${req.params.integration}` }
 
   // @ts-ignore
-  req.data = { ...req.data, api }
+  req.data = { ...req.data, integration }
 
   return next()
 })
@@ -184,7 +184,7 @@ dashboard.get('/:integration/configurations/new', (req, res) => {
 dashboard.post('/:integration/configurations/new', async (req, res) => {
   const scopes = integrations.validateConfigurationScopes(String(req.body.scopes))
   // @ts-ignore
-  const integration = req.data.api as Types.Integration
+  const integration = req.data.integration as Types.Integration
   const newCredentials = formatSetup(String(req.body.setupKey), String(req.body.setupSecret), integration)
   const credentials = integrations.validateConfigurationCredentials(newCredentials, integration)
   const setup_id = uuidv4()
@@ -229,7 +229,7 @@ dashboard.get('/:integration/configurations/:setupId', async (req, res, next) =>
 dashboard.post('/:integration/configurations/:setupId', async (req, res) => {
   const setupId = String(req.params.setupId)
   // @ts-ignore
-  const integration = req.data.api as Types.Integration
+  const integration = req.data.integration as Types.Integration
   const newCredentials = formatSetup(String(req.body.setupKey), String(req.body.setupSecret), integration)
   const credentials = integrations.validateConfigurationCredentials(newCredentials, integration)
   const scopes = integrations.validateConfigurationScopes(String(req.body.scopes))

--- a/views/assets/css/dashboard.css
+++ b/views/assets/css/dashboard.css
@@ -272,7 +272,7 @@ form fieldset .form-input,
 }
 
 .form-json .json-formatter-string {
-  white-space: pre-wrap;
+  white-space: pre-wrap !important;
 }
 
 form fieldset .form-hint {

--- a/views/dashboard/api-authentications-connect.ejs
+++ b/views/dashboard/api-authentications-connect.ejs
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-  <%- include('layout-head', { title: `Connect to ${req.data.api.name}` }) %>
+  <%- include('layout-head', { title: `Connect to ${req.data.integration.name}` }) %>
 
   <body>
     <!-- Header -->
@@ -8,7 +8,7 @@
 
     <main class="container">
       <section>
-        <h2>Connect to <%= req.data.api.name %></h2>
+        <h2>Connect to <%= req.data.integration.name %></h2>
         <form>
           <fieldset>
             <label>Callback URL</label>
@@ -24,7 +24,7 @@
             <input disabled="disabled" type="text" class="form-input" id="authId" />
           </fieldset>
           <div class="form-actions">
-            <button type="submit" class="button button-primary">Connect to <%= req.data.api.name %></button>
+            <button type="submit" class="button button-primary">Connect to <%= req.data.integration.name %></button>
             <a class="button" href="javascript:history.back()">Cancel</a>
             <p id="status"></p>
           </div>

--- a/views/dashboard/api-authentications-item.ejs
+++ b/views/dashboard/api-authentications-item.ejs
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-  <%- include('layout-head', { title: `Authentications - ${req.data.api.name} API` }) %>
+  <%- include('layout-head', { title: `Authentications - ${req.data.integration.name} API` }) %>
 
   <body>
     <!-- Header -->

--- a/views/dashboard/api-authentications-list.ejs
+++ b/views/dashboard/api-authentications-list.ejs
@@ -4,7 +4,6 @@
       <tr>
         <th>Auth ID</th>
         <th>Setup ID</th>
-        <th>Scopes</th>
         <th class="col-date">Last modified</th>
         <th class="col-actions"></th>
       </tr>
@@ -12,13 +11,12 @@
     <tbody>
       <% req.data.authentications.forEach(function(auth){ %>
       <tr
-        data-item-integration="<%= req.data.api.id %>"
+        data-item-integration="<%= req.data.integrationid %>"
         data-item-type="authentication"
         data-item-id="<%= auth.auth_id %>"
       >
         <td><%= auth.auth_id %></td>
         <td><%= auth.setup_id %></td>
-        <td></td>
         <td class="col-date">
           <%= new Date(auth.updated_at).toLocaleString('en-US', req.ejs.datetimeOptions) %>
         </td>

--- a/views/dashboard/api-authentications.ejs
+++ b/views/dashboard/api-authentications.ejs
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-  <%- include('layout-head', { title: `Authentications - ${req.data.api.name} API` }) %>
+  <%- include('layout-head', { title: `Authentications - ${req.data.integration.name} API` }) %>
 
   <body>
     <!-- Header -->
@@ -12,7 +12,7 @@
           <h2>Authentications</h2>
           <aside>
             <a href="<%= req.ejs.base_url %>/authentications/connect" class="button button-primary"
-              >Connect to <%= req.data.api.name %></a
+              >Connect to <%= req.data.integration.name %></a
             >
           </aside>
         </header>

--- a/views/dashboard/api-configurations-edit.ejs
+++ b/views/dashboard/api-configurations-edit.ejs
@@ -1,7 +1,7 @@
 <% const base = `/dashboard/${req.params.api}`; %>
 <!DOCTYPE html>
 <html>
-  <%- include('layout-head', { title: `Edit configuration - ${req.data.api.name} API`}) %>
+  <%- include('layout-head', { title: `Edit configuration - ${req.data.integration.name} API`}) %>
 
   <body>
     <!-- Header -->
@@ -15,7 +15,7 @@
 
         <form method="POST">
           <fieldset>
-            <label for="setupKey"><%= req.data.api.config.setupKeyLabel %></label>
+            <label for="setupKey"><%= req.data.integration.auth.setupKeyLabel %></label>
             <input
               id="setupKey"
               type="text"
@@ -27,7 +27,7 @@
           </fieldset>
 
           <fieldset>
-            <label for="setupSecret"><%= req.data.api.config.setupSecretLabel %></label>
+            <label for="setupSecret"><%= req.data.integration.auth.setupSecretLabel %></label>
             <input
               id="setupSecret"
               type="password"

--- a/views/dashboard/api-configurations-list.ejs
+++ b/views/dashboard/api-configurations-list.ejs
@@ -3,8 +3,8 @@
     <thead>
       <tr>
         <th>Setup ID</th>
-        <th><%= req.data.api.config.setupKeyLabel %></th>
-        <th><%= req.data.api.config.setupSecretLabel %></th>
+        <th><%= req.data.integration.auth.setupKeyLabel %></th>
+        <th><%= req.data.integration.auth.setupSecretLabel %></th>
         <th class="col-center">Scopes</th>
         <th class="col-date">Creation date</th>
         <th class="col-actions"></th>
@@ -13,7 +13,7 @@
     <tbody>
       <% req.data.configurations.forEach(function(configuration){ %>
       <tr
-        data-item-integration="<%= req.data.api.id %>"
+        data-item-integration="<%= req.data.integration.id %>"
         data-item-type="configuration"
         data-item-id="<%= configuration.setupId %>"
       >

--- a/views/dashboard/api-configurations-new.ejs
+++ b/views/dashboard/api-configurations-new.ejs
@@ -1,7 +1,7 @@
 <% const base = `/dashboard/${req.params.api}`; %>
 <!DOCTYPE html>
 <html>
-  <%- include('layout-head', { title: `New configuration - ${req.data.api.name} API`}) %>
+  <%- include('layout-head', { title: `New configuration - ${req.data.integration.name} API`}) %>
 
   <body>
     <!-- Header -->
@@ -15,12 +15,12 @@
 
         <form method="POST">
           <fieldset>
-            <label for="setupKey"><%= req.data.api.config.setupKeyLabel %></label>
+            <label for="setupKey"><%= req.data.integrationconfig.setupKeyLabel %></label>
             <input id="setupKey" type="text" class="form-input" name="setupKey" required />
           </fieldset>
 
           <fieldset>
-            <label for="setupSecret"><%= req.data.api.config.setupSecretLabel %></label>
+            <label for="setupSecret"><%= req.data.integrationconfig.setupSecretLabel %></label>
             <input id="setupSecret" type="password" class="form-input" name="setupSecret" required />
           </fieldset>
 

--- a/views/dashboard/api-configurations.ejs
+++ b/views/dashboard/api-configurations.ejs
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-  <%- include('layout-head', { title: `Configurations - ${req.data.api.name} API`}) %>
+  <%- include('layout-head', { title: `Configurations - ${req.data.integration.name} API`}) %>
 
   <body>
     <!-- Header -->

--- a/views/dashboard/api-monitoring.ejs
+++ b/views/dashboard/api-monitoring.ejs
@@ -2,7 +2,7 @@
 
 <!DOCTYPE html>
 <html>
-  <%- include('layout-head', { title: `Monitoring - ${req.data.api.name} API`}) %>
+  <%- include('layout-head', { title: `Monitoring - ${req.data.integration.name} API`}) %>
 
   <body>
     <!-- Header -->

--- a/views/dashboard/api-request.ejs
+++ b/views/dashboard/api-request.ejs
@@ -2,7 +2,7 @@
 
 <!DOCTYPE html>
 <html>
-  <%- include('layout-head', { title: `Request - ${req.data.api.name} API`}) %>
+  <%- include('layout-head', { title: `Request - ${req.data.integration.name} API`}) %>
 
   <body>
     <!-- Header -->
@@ -24,7 +24,7 @@
 
           <fieldset>
             <label>Base URL</label>
-            <input value="<%= req.data.api.request.baseURL %>" disabled="disabled" class="form-input" />
+            <input value="<%= req.data.integration.request.baseURL %>" disabled="disabled" class="form-input" />
             <p class="form-hint">The base URL has been inferred from the API configuration file.</p>
           </fieldset>
 

--- a/views/dashboard/api.ejs
+++ b/views/dashboard/api.ejs
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-  <%- include('layout-head', { title: `${req.data.api.name} API`}) %>
+  <%- include('layout-head', { title: `${req.data.integration.name} API`}) %>
 
   <body>
     <!-- Header -->
@@ -44,7 +44,7 @@
           <h2 class="section-heading">Authenticated users</h2>
           <aside>
             <a href="<%= req.ejs.base_url %>/authentications/connect" class="button button-primary"
-              >Connect to <%= req.data.api.name %></a
+              >Connect to <%= req.data.integrationname %></a
             >
           </aside>
         </header>

--- a/views/dashboard/layout-header-api.ejs
+++ b/views/dashboard/layout-header-api.ejs
@@ -4,7 +4,7 @@
   <div class="container">
     <a href="/dashboard/"><img src="/assets/img/logos/pizzly.png" class="logo" alt="Pizzly"/></a>
 
-    <h1><a href="/dashboard/">APIs</a> <span class="separator">/</span> <%= req.data.api.name %></h1>
+    <h1><a href="/dashboard/">APIs</a> <span class="separator">/</span> <%= req.data.integration.name %></h1>
 
     <nav>
       <ol>


### PR DESCRIPTION
# Description

Removed default scope on the integrations' configuration. And also renamed the `config` property to `auth` as it's related to the authentication.

Here's an example of a new configuration file:

```json
{
  "name": "Google Sheets",
  "image": "https://upload.wikimedia.org/wikipedia/commons/1/11/Google-Sheets-Logo-2019.png",
  "auth": {
    "authorizationURL": "https://accounts.google.com/o/oauth2/v2/auth",
    "tokenURL": "https://www.googleapis.com/oauth2/v4/token",
    "authType": "OAUTH2",
    "tokenParams": { "grant_type": "authorization_code" },
    "authorizationParams": { "prompt": "consent", "access_type": "offline" },
    "auth": {
      "response_type": "code"
    }
  },
  "request": {
    "baseURL": "https://sheets.googleapis.com/v4/spreadsheets/",
    "headers": {
      "Accept": "application/json",
      "Authorization": "Bearer ${auth.accessToken}",
      "Content-Type": "application/json",
      "User-Agent": "Pizzly"
    }
  }
}
```