### PR TITLE
Add first version of a production Dockefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# This is the Dockerfile for building a production image with Pizzly
+
+
+# Build image 
+FROM node:13.5.0-alpine3.11
+
+WORKDIR /app
+
+# Copy in dependencies for building
+COPY *.json ./
+COPY yarn.lock ./
+COPY config ./config
+COPY integrations ./integrations/
+COPY src ./src/
+COPY tests ./tests/
+COPY views ./views/
+
+RUN yarn install 
+
+
+# Actual image to run from.
+FROM node:13.5.0-alpine3.11
+
+# Make sure we have ca certs for TLS
+RUN apk --no-cache add ca-certificates
+
+# Make a directory for the node user. Not running Pizzly as root.
+RUN mkdir /home/node/app && chown -R node:node /home/node/app
+WORKDIR /home/node/app
+
+USER node
+
+COPY --chown=node:node --from=0 /app/dist/ .
+COPY --chown=node:node --from=0 /app/node_modules ./node_modules
+
+CMD ["node", "src"]


### PR DESCRIPTION
Hi @Frenchcooc 

As promised, this is a small contribution with a Dockerfile. We will be using this internally to run Pizzly on our Kubernetes cluster.

This is just a simple Dockerfile added with two build stages. 

The first stage installs all dependencies and builds the app into the dist dir.  
The second stage changes the user to `node` and copies over the dependencies and the dist dir from the build stage image. This way there are no other files than what we need to run Pizzly in the image. 

**Caveats**
- I have not added any documentation on how to build and use the image. For people familiar with Docker, this should be easy though.
- We might be able to slim down the final image even more by using a base image, that does not include yarn or npm, but only the node runtime. 

**Future work**
- Add either a Dockfile for local or just use this one and add it to the `docker-compose.yml` for very easy local setup.