### PR TITLE
fix: add views directory to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ WORKDIR /home/node/app
 USER node
 
 COPY --chown=node:node --from=0 /app/dist/ .
+COPY --chown=node:node --from=0 /app/views ./views
 COPY --chown=node:node --from=0 /app/node_modules ./node_modules
 
 CMD ["node", "src"]


### PR DESCRIPTION
When deploying the Docker image to production, we realized that the views directory was not copied into the dist dir.  

This PR adds the views explicitly to the resulting image.