### PR TITLE
Update Xero integration from OAuth1 to OAuth2

### DIFF
--- a/integrations/xero.json
+++ b/integrations/xero.json
@@ -1,16 +1,18 @@
 {
   "name": "Xero",
   "auth": {
-    "accessTokenURL": "https://api.xero.com/oauth/AccessToken",
-    "authorizationParams": {},
-    "authType": "OAUTH1",
-    "requestTokenURL": "https://api.xero.com/oauth/RequestToken",
-    "signatureMethod": "HMAC-SHA1",
-    "tokenParams": {},
-    "userAuthorizationURL": "https://api.xero.com/oauth/Authorize"
+    "authType": "OAUTH2",
+    "authorizationParams": { "response_type": "code" },
+    "authorizationURL": "https://login.xero.com/identity/connect/authorize"
+    "tokenParams": { "grant_type": "authorization_code" },
+    "tokenURL": "https://identity.xero.com/connect/token",
   },
   "request": {
-    "baseURL": "https://api.xero.com/api.xro/2.0/",
-    "headers": { "Accept": "application/json", "Authorization": "OAuth ${auth.oauth1}", "User-Agent": "Pizzly" }
+    "baseURL": "https://api.xero.com/",
+    "headers": {
+      "User-Agent": "Pizzly",
+      "Authorization": "Bearer ${auth.accessToken}",
+      "Accept": "application/json",
+    }
   }
 }

--- a/integrations/xero.json
+++ b/integrations/xero.json
@@ -3,16 +3,16 @@
   "auth": {
     "authType": "OAUTH2",
     "authorizationParams": { "response_type": "code" },
-    "authorizationURL": "https://login.xero.com/identity/connect/authorize"
+    "authorizationURL": "https://login.xero.com/identity/connect/authorize",
     "tokenParams": { "grant_type": "authorization_code" },
-    "tokenURL": "https://identity.xero.com/connect/token",
+    "tokenURL": "https://identity.xero.com/connect/token"
   },
   "request": {
     "baseURL": "https://api.xero.com/",
     "headers": {
       "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}",
-      "Accept": "application/json",
+      "Accept": "application/json"
     }
   }
 }


### PR DESCRIPTION
OAuth1 has been deprecated by Xero since Feb 2020:
https://devblog.xero.com/an-update-on-why-we-are-saying-goodbye-oauth-1-0a-hello-oauth-2-0-6a839230908f

Here's a PR to support OAuth 2. Our app didn't actually work (mentioned #63) with OAuth1 because it was made in March!

I had to change the baseURL to `https://api.xero.com` rather than the previous `https://api.xero.com/api.xro/2.0/`.

Xero requires a `xero-tenant-id` header to be passed with subsequent requests to gain access to business accounts the user has access to.

The only way to get this `xero-tenant-id` is to query:

`GET https://api.xero.com/connections`

Then after obtaining the tenant ID you can query:

`GET https://api.xero.com/api.xro/2.0/...` with an added header `xero-tenant-id: "abcdefg-12345"`.

Question: Is there an organization plan for the json files for different supported OAuth versions? E.g. `xero, xero-oauth1, xero-oauth2`?