### PR TITLE
Fix/node js tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "jest-localstorage-mock": "^2.2.0",
     "lint-staged": "^8.1.0",
     "nock": "^10.0.1",
+    "node-fetch": "^2.6.0",
     "nodemon": "^2.0.2",
     "prettier": "^1.15.3",
     "rimraf": "^3.0.2",

--- a/src/clients/node/README.md
+++ b/src/clients/node/README.md
@@ -17,7 +17,7 @@ yarn add pizzly-node
 Once a user is connected, you can use its [`authId`](https://github.com/Bearer/Pizzly/wiki/Reference-:-Auth#the-authid-concept) to query any endpoint of the API.
 
 ```js
-const Pizzly = require('pizzly-node')
+const Pizzly = require('pizzly-node') // or import { Pizzly } from 'pizzly-node'
 
 const pizzly = new Pizzly({ host: 'pizzly.example.org' }) // Initialize Pizzly with your own instance
 const myAPI = pizzly.integration('x-api') // Replace with the API slugname
@@ -51,7 +51,7 @@ myAPI
 It's highly recommended to secure your Pizzly instance after deployment ([learn more](https://github.com/Bearer/Pizzly/wiki/Secure-your-instance)). Once you've added a secret key, pass it to the client as follow:
 
 ```js
-const Pizzly = require('pizzly-node')
+const Pizzly = require('pizzly-node') // or import { Pizzly } from 'pizzly-node'
 
 const pizzly = new Pizzly({
   host: 'x-replace-with-your-pizzly-instance',

--- a/src/clients/node/examples/index.js
+++ b/src/clients/node/examples/index.js
@@ -1,0 +1,12 @@
+const Pizzly = require('../dist') // require local build (similar to const Pizzly = require('pizzly-node'))
+
+const pizzly = new Pizzly({ host: 'pizzly.example.org' })
+
+console.log(pizzly.origin) // will be "https://pizzly.example.org/"
+console.log(pizzly.key) // will "" (empty string)
+
+const github = pizzly.integration('github')
+const githubUser = github.auth('replace-with-a-valid-auth-id')
+
+githubUser.get('/user')
+githubUser.put('/user/starred/bearer/pizzly')

--- a/src/clients/node/jest.config.js
+++ b/src/clients/node/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-};

--- a/src/clients/node/package.json
+++ b/src/clients/node/package.json
@@ -25,5 +25,8 @@
   "repository": "bearer/pizzly",
   "homepage": "https://github.com/Bearer/Pizzly/tree/master/src/clients/javascript#readme",
   "author": "Bearer Team <engineering@bearer.sh>",
-  "license": "MIT"
+  "license": "MIT",
+  "jest": {
+    "preset": "ts-jest"
+  }
 }

--- a/src/clients/node/src/index.ts
+++ b/src/clients/node/src/index.ts
@@ -48,5 +48,8 @@ class Pizzly {
   }
 }
 
-export default Pizzly
 module.exports = Pizzly
+module.exports.Pizzly = Pizzly
+module.exports.default = Pizzly
+
+export { Pizzly }

--- a/src/clients/node/test/init.test.ts
+++ b/src/clients/node/test/init.test.ts
@@ -1,4 +1,4 @@
-import Pizzly from '../src/index'
+import { Pizzly } from '../src/index'
 
 describe('Pizzly class', () => {
   describe('constructor', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4850,6 +4850,11 @@ nock@^10.0.1:
     qs "^6.5.1"
     semver "^5.5.0"
 
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
# Description

Provide best of both world between Javascript and Typescript to require/import `pizzly-node`. Also udpated the README + added a few examples on how to use it.

Here's how to require `pizzly-node` in a Node.js app:

```js
const Pizzly = require('pizzly-node')
```

Here's how to import `pizzly-node` in a Node.js + Typescript app:

```js
import { Pizzly } from 'pizzly-node'
```