### PR TITLE
Force Pizzly-js to listen to the right events

### DIFF
--- a/src/clients/javascript/package.json
+++ b/src/clients/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pizzly-js",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A JavaScript library that enables Pizzly on your website",
   "main": "dist/index.js",
   "module": "dist/index.min.mjs",

--- a/src/clients/javascript/src/connect.ts
+++ b/src/clients/javascript/src/connect.ts
@@ -44,6 +44,14 @@ export default class PizzlyConnect {
           return
         }
 
+        // If the event origin is different from the Pizzly's instance
+        // do not handle that event. Some APIs consent screeens triggers
+        // postMessage. This make sure that it does not interfer with pizzly-js
+        // To learn more: https://github.com/Bearer/Pizzly/issues/75
+        if (e && new URL(e.origin).origin !== new URL(this.origin).origin) {
+          return
+        }
+
         this.status = AuthorizationStatus.DONE
 
         if (!e) {
@@ -52,8 +60,8 @@ export default class PizzlyConnect {
           return reject(new Error(errorMessage))
         }
 
-        if (!e.data) {
-          const errorMessage = 'Authorization failed. The response is not supported.'
+        if (!e.data || !e.data.event) {
+          const errorMessage = 'Authorization failed. The authorization modal sent an unsupported MessageEvent.'
           return reject(new Error(errorMessage))
         }
 
@@ -65,7 +73,7 @@ export default class PizzlyConnect {
           return reject(event.data)
         }
 
-        reject(new Error('Authorization failed. The response type is not supported'))
+        reject(new Error('Authorization failed. That’s all we know.'))
       }
 
       // Add an event listener on authorization modal


### PR DESCRIPTION
# Description

Following issue #75, it appeared that SmartPension API triggers some postMessage events within the authorization modal. It's something that wasn't anticipated by `pizzly-js`, which was reacting to any single events that it received from the modal. 

This PR make sure that only the messages having the same origin than the the callback URL are processed.