### PR TITLE
Fix/connect messageevent validation

### DIFF
--- a/src/clients/javascript/package.json
+++ b/src/clients/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pizzly-js",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A JavaScript library that enables Pizzly on your website",
   "main": "dist/index.js",
   "module": "dist/index.min.mjs",

--- a/src/clients/javascript/src/connect.ts
+++ b/src/clients/javascript/src/connect.ts
@@ -60,7 +60,7 @@ export default class PizzlyConnect {
           return reject(new Error(errorMessage))
         }
 
-        if (!e.data || !e.data.event) {
+        if (!e.data || !e.data.eventType) {
           const errorMessage = 'Authorization failed. The authorization modal sent an unsupported MessageEvent.'
           return reject(new Error(errorMessage))
         }


### PR DESCRIPTION
# Description

Fix a typo with #76. The `MessageEvent` validation was requiring an `event` property, but it should be an `eventType`.