### PR TITLE
Fix an issue with the trash icon on the dashboard

### DIFF
--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -248,7 +248,7 @@ dashboard.post('/:integration/configurations/:setupId', async (req, res) => {
 })
 
 /**
- * Delete a configuration from the dashboar (little trash icon)
+ * Delete a configuration from the dashboard (little trash icon)
  */
 
 dashboard.delete('/:integration/configurations/:setupId', async (req, res, next) => {
@@ -311,7 +311,7 @@ dashboard.get('/:integration/authentications/:authId', async (req, res) => {
 })
 
 /**
- * Delete a configuration from the dashboar (little trash icon)
+ * Delete an authentication from the dashboard (little trash icon)
  */
 
 dashboard.delete('/:integration/authentications/:setupId', async (req, res, next) => {

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -9,6 +9,7 @@
 import * as express from 'express'
 import bodyParser from 'body-parser'
 import { v4 as uuidv4 } from 'uuid'
+import axios from 'axios'
 import * as integrations from '../lib/database/integrations'
 import { store } from '../lib/database'
 import * as access from '../lib/access'
@@ -247,6 +248,21 @@ dashboard.post('/:integration/configurations/:setupId', async (req, res) => {
 })
 
 /**
+ * Delete a configuration from the dashboar (little trash icon)
+ */
+
+dashboard.delete('/:integration/configurations/:setupId', async (req, res, next) => {
+  const url = req.protocol + '://' + req.get('host') + req.originalUrl.replace('/dashboard/', '/api/')
+
+  const credentials = Buffer.from(`${process.env.SECRET_KEY}:`, 'utf8').toString('base64')
+
+  await axios
+    .delete(url, { headers: { Authorization: `Basic ${credentials}` } })
+    .then(({ data }) => res.json(data))
+    .catch(next)
+})
+
+/**
  * Integration > Authentications
  */
 
@@ -292,6 +308,21 @@ dashboard.get('/:integration/authentications/:authId', async (req, res) => {
   req.data = { ...req.data, authentication }
 
   res.render('dashboard/api-authentications-item', { req })
+})
+
+/**
+ * Delete a configuration from the dashboar (little trash icon)
+ */
+
+dashboard.delete('/:integration/authentications/:setupId', async (req, res, next) => {
+  const url = req.protocol + '://' + req.get('host') + req.originalUrl.replace('/dashboard/', '/api/')
+
+  const credentials = Buffer.from(`${process.env.SECRET_KEY}:`, 'utf8').toString('base64')
+
+  await axios
+    .delete(url, { headers: { Authorization: `Basic ${credentials}` } })
+    .then(({ data }) => res.json(data))
+    .catch(next)
 })
 
 /**

--- a/views/assets/js/dashboard.js
+++ b/views/assets/js/dashboard.js
@@ -36,5 +36,7 @@ const removeItem = event => {
     item.parentNode.removeChild(item)
   }, 800)
 
-  fetch(`/api/${integration}/${type + 's'}/${id}`, { method: 'DELETE' }).catch(console.error)
+  fetch(`/dashboard/${integration}/${type + 's'}/${id}`, {
+    method: 'DELETE'
+  }).catch(console.error)
 }


### PR DESCRIPTION
# Description

Thanks @gotbadger for reporting this bug. The trash icon wasn't deleting an authentication (or configuration) when the Pizzly instance was protected behing a secretKey. Now it does.

![Screenshot 2020-07-17 at 15 45 41](https://user-images.githubusercontent.com/3255133/87792764-a59bbd80-c844-11ea-9c2d-9086b148fdd3.png)
