### PR TITLE
Fix/refresh o auth2 token

### DIFF
--- a/src/lib/database/authentications.ts
+++ b/src/lib/database/authentications.ts
@@ -26,8 +26,18 @@ export const get = getAuthentication // Alias
  * @param authId (string) - The authentication ID
  */
 
-export const update = async (authId: string, newData: Types.Authentication): Promise<Types.Authentication> => {
+export const update = async (
+  authId: string,
+  newAuthentication: Types.Authentication
+): Promise<Types.Authentication> => {
+  const newRecord = {
+    auth_id: newAuthentication.auth_id,
+    setup_id: newAuthentication.setup_id,
+    payload: newAuthentication.payload,
+    updated_at: new Date()
+  }
+
   return await store('authentications')
     .where({ auth_id: authId })
-    .update(newData)
+    .update(newRecord)
 }


### PR DESCRIPTION
## Proposed changes

Trying to refresh a token was throwing an error due to a mismatch with how the data are stored in the database.

This PR:
- makes sure the data is correctly saved;
- and introduce a new endpoint `POST /api/{api-name}/authentications/{auth-id}/refresh` to force refreshing the token at anytime (in link with issue #60).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bearer/pizzly/blob/master/README.md#contributing-guide) guide
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules