### PR TITLE
fix (client): handle param options

### DIFF
--- a/src/clients/javascript/src/connect.ts
+++ b/src/clients/javascript/src/connect.ts
@@ -112,6 +112,15 @@ export default class PizzlyConnect {
       query.push(`setupId=${options.setupId}`)
     }
 
+    if (options && typeof options.params !== 'undefined') {
+      for (const param in options.params) {
+        const val = options.params[param]
+        if (typeof val === 'string') {
+          query.push(`params[${param}]=${val}`)
+        }
+      }
+    }
+
     return query.join('&')
   }
 }

--- a/src/clients/javascript/src/types.ts
+++ b/src/clients/javascript/src/types.ts
@@ -2,6 +2,7 @@ declare namespace Types {
   export interface ConnectOptions {
     authId?: string
     setupId?: string
+    params?: any
   }
 
   export interface ConnectSuccess {


### PR DESCRIPTION
## Proposed changes

Adds any fields added to a `params` field in the options object, when connecting to the upstream API. This follows the assumptions made on the server side that additional params can be passed in this way.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bearer/pizzly/blob/master/README.md#contributing-guide) guide
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

No tests were added here, but the upsteam did not test the method anyway.