### PR TITLE
fix: APIs using client_credentials as grant type

### DIFF
--- a/integrations/moltin.json
+++ b/integrations/moltin.json
@@ -3,7 +3,7 @@
   "auth": {
     "authType": "OAUTH2",
     "bodyFormat": "form",
-    "tokenParams": { "grant_type": "client_credentials" },
+    "grantType": "client_credentials",
     "authorizationMethod": "body",
     "tokenURL": "https://api.moltin.com/oauth/access_token"
   },

--- a/integrations/snov.json
+++ b/integrations/snov.json
@@ -3,9 +3,9 @@
   "image": "https://logo.clearbit.com/snov.io",
   "auth": {
     "authType": "OAUTH2",
+    "grantType": "client_credentials",
     "bodyFormat": "form",
-    "tokenParams": { "grant_type": "client_credentials" },
-    "tokenURL": "https://app.snov.io/oauth/access_token",
+    "tokenURL": "https://api.snov.io/v1/oauth/access_token",
     "authorizationMethod": "body",
     "authorizationParams": {}
   },
@@ -15,7 +15,7 @@
       "User-Agent": "Pizzly",
       "Authorization": "Bearer ${auth.accessToken}"
     },
-    "baseURL": "https://app.snov.io/restapi/",
+    "baseURL": "https://api.snov.io/",
     "params": {}
   }
 }

--- a/src/legacy/auth/v3/strategies/oauth2/client-credentials.ts
+++ b/src/legacy/auth/v3/strategies/oauth2/client-credentials.ts
@@ -8,7 +8,7 @@ import { responseToCredentials } from './common'
 export const authenticate = asyncMiddleware(async (req: TAuthenticateRequest, _res: Response, next: NextFunction) => {
   const { authorizationMethod, bodyFormat, config, tokenURL } = req.integrationConfig
   const { scope = [] } = config || {}
-  const { clientId, clientSecret } = req.setupDetails
+  const { clientId, clientSecret } = req.setupDetails.credentials
 
   const tokenResult = await getTokenWithClientCredentials({
     authorizationMethod,


### PR DESCRIPTION
## Proposed changes

Looks like the `ClientCredentials` strategy for OAuth 2.0 was not well-handled during the open-source migration. Only two APIs (Snov.io and Moltin) are concerned. That's probably the reason why this hasn't been detected sooner.

Also the configuration for Snov.io was not well-made. This has been fixed and tested (manually).

## Types of changes

What types of changes does your code introduce to Pizzly?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/bearer/pizzly/blob/master/README.md#contributing-guide) guide
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

We definitely need better logging in all aspects, as well as tests on the API integrations.