### PR TITLE
feat: improve error message on token refreshness

### DIFF
--- a/src/lib/error-handling/index.ts
+++ b/src/lib/error-handling/index.ts
@@ -91,6 +91,12 @@ export class PizzlyError extends Error {
         break
 
       // Something failed
+      case 'token_refresh_missing':
+        this.status = 422
+        this.message =
+          'Unable to refresh the token. That user has no refresh token. The API might have not providing one.'
+        break
+
       case 'token_refresh_failed':
         this.status = 422
         this.message = 'Unable to refresh the token. Please re-connect that user.'

--- a/src/lib/proxy/index.ts
+++ b/src/lib/proxy/index.ts
@@ -41,18 +41,19 @@ export const incomingRequestHandler = async (req, res, next) => {
     return next(new PizzlyError('unknown_authentication'))
   }
 
-  // Handle the token freshness (if it has expired)
-  if (await accessTokenHasExpired(authentication)) {
-    authentication = await refreshAuthentication(integration, authentication)
+  try {
+    // Handle the token freshness (if it has expired)
+    if (await accessTokenHasExpired(authentication)) {
+      authentication = await refreshAuthentication(integration, authentication)
+    }
+
     if (!authentication) {
       return next(new PizzlyError('token_refresh_failed')) // TODO: improve error verbosity
     }
-  }
-  try {
+
     // Replace request options with provided authentication or data
     // i.e. replace ${auth.accessToken} from the integration template
     // with the authentication access token retrieved from the database.
-
     const forwardedHeaders = headersToForward(req.rawHeaders)
     const { url, headers } = await buildRequest({
       authentication,

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -311,6 +311,10 @@ api.post('/:integrationId/authentications/:authId/refresh', async (req, res, nex
     const authentication = await refreshAuthentication(integration, oldAuthentication)
     res.json({ message: 'Authentication refreshed', authentication })
   } catch (err) {
+    if (err instanceof PizzlyError) {
+      return next(err)
+    }
+
     return next(new PizzlyError('token_refresh_failed'))
   }
 })


### PR DESCRIPTION
## Proposed changes

Improve the error message when trying to refresh an authentication but there's none refreshToken saved (see feedback in #173). The new error message in that case would be:

```json
{"error":{"type":"token_refresh_missing","message":"Unable to refresh the token. That user has no refresh token. The API might have not providing one."}}
```

## Types of changes

What types of changes does your code introduce to Pizzly?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/bearer/pizzly/blob/master/README.md#contributing-guide) guide
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
