### PR TITLE
Swap scope non-null operator to optional operator

### DIFF
--- a/src/legacy/auth/v3/strategies/oauth2/auth-code.ts
+++ b/src/legacy/auth/v3/strategies/oauth2/auth-code.ts
@@ -56,7 +56,7 @@ export const authenticate = asyncMiddleware(async (req: TAuthenticateRequest, re
     authorizationURL,
     clientId,
     state,
-    scope: scopes || config!.scope || [],
+    scope: scopes || config?.scope || [],
     callbackURL
   })
 


### PR DESCRIPTION
Should resolve #191 and issues with APIs that don't require scopes.