### PR TITLE
FIX: Invalid Google cloud URL

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -92,7 +92,7 @@ To make sure Pizzly works well and can help your engineering team, you need to c
 On the API developer's website, you'll first need to create an application. Some API call it an "OAuth application" which is more precise, but it's the same. Here are a few links on where to create an OAuth application:
 
 - For GitHub, [open your developer settings](https://github.com/settings/developers)
-- For Google APIs, head to the [Google Cloud Console](console.cloud.google.com/) > API > Credentials
+- For Google APIs, head to the [Google Cloud Console](https://console.cloud.google.com/) > API > Credentials
 - For Slack, [open your apps in the Slack API](https://api.slack.com/apps)
 
 _Websites change and a link might be broken. Feel free to edit the page if you spot something wrong._


### PR DESCRIPTION
Correct markdown url by adding `https` prefix

## Proposed changes

Click on `Google Cloud Console` link in README causes 404 not found error. Adding `https` scheme fixes the problem.

## Types of changes

What types of changes does your code introduce to Pizzly?

- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/bearer/pizzly/blob/master/README.md#contributing-guide) guide
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
